### PR TITLE
Add multi-step onboarding flow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 env:
   SCHEME: CodeDump
   PROJECT: CodeDump.xcodeproj
-  DESTINATION: "platform=iOS Simulator,name=iPhone 16 Pro,OS=latest"
+  DESTINATION: "platform=iOS Simulator,name=iPhone 17 Pro,OS=latest"
   COVERAGE_THRESHOLD: 70
 
 jobs:

--- a/CodeDump/Features/Onboarding/OnboardingEquipmentStep.swift
+++ b/CodeDump/Features/Onboarding/OnboardingEquipmentStep.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+struct OnboardingEquipmentStep: View {
+    @Binding var equipmentRaw: String
+
+    @State private var selectedEquipment: Set<Equipment> = []
+    @State private var selectedPreset: EquipmentProfile.Preset = .commercialGym
+
+    var body: some View {
+        VStack(spacing: 24) {
+            // Header
+            VStack(spacing: 8) {
+                Image(systemName: "dumbbell.fill")
+                    .font(.system(size: 32))
+                    .foregroundColor(.outrunYellow)
+
+                Text("YOUR GYM")
+                    .font(.outrunFuture(24))
+                    .foregroundColor(.white)
+
+                Text("What equipment do you have access to?")
+                    .font(.outrunFuture(12))
+                    .foregroundColor(.white.opacity(0.5))
+            }
+
+            // Presets
+            HStack(spacing: 8) {
+                ForEach(EquipmentProfile.Preset.allCases) { preset in
+                    presetButton(preset)
+                }
+            }
+            .padding(.horizontal, 24)
+
+            // Equipment grid
+            ScrollView {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 140), spacing: 10)], spacing: 10) {
+                    ForEach(Equipment.allCases) { equip in
+                        equipmentToggle(equip)
+                    }
+                }
+                .padding(.horizontal, 24)
+            }
+            .frame(maxHeight: 280)
+
+            // Summary
+            let exerciseCount = EquipmentProfile.availableExerciseCount(for: selectedEquipment)
+            Text("\(selectedEquipment.count) equipment types \u{2022} \(exerciseCount) exercises available")
+                .font(.outrunFuture(11))
+                .foregroundColor(.outrunYellow)
+        }
+        .onAppear {
+            selectedEquipment = EquipmentProfile.decode(equipmentRaw)
+            selectedPreset = EquipmentProfile.inferPreset(from: selectedEquipment)
+        }
+        .onChange(of: selectedEquipment) {
+            equipmentRaw = EquipmentProfile.encode(selectedEquipment)
+            selectedPreset = EquipmentProfile.inferPreset(from: selectedEquipment)
+        }
+    }
+
+    // MARK: - Preset Button
+
+    private func presetButton(_ preset: EquipmentProfile.Preset) -> some View {
+        let isActive = selectedPreset == preset
+        return Button {
+            selectedPreset = preset
+            if preset != .custom {
+                selectedEquipment = EquipmentProfile.equipment(for: preset)
+            }
+        } label: {
+            Text(preset.rawValue.uppercased())
+                .font(.outrunFuture(10))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 10)
+                .background(isActive ? Color.outrunPink.opacity(0.35) : Color.outrunBlack)
+                .foregroundColor(isActive ? .outrunPink : .white.opacity(0.5))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(isActive ? Color.outrunPink : Color.clear, lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Equipment Toggle
+
+    private func equipmentToggle(_ equip: Equipment) -> some View {
+        let isSelected = selectedEquipment.contains(equip)
+        let isInteractive = selectedPreset == .custom
+
+        return Button {
+            guard isInteractive else { return }
+            if isSelected {
+                selectedEquipment.remove(equip)
+            } else {
+                selectedEquipment.insert(equip)
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: equip.icon)
+                    .font(.system(size: 14))
+                Text(equip.displayName)
+                    .font(.outrunFuture(11))
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 10)
+            .background(isSelected ? Color.outrunCyan.opacity(0.3) : Color.outrunBlack)
+            .foregroundColor(isSelected ? .outrunCyan : .white.opacity(0.35))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(isSelected ? Color.outrunCyan : Color.clear, lineWidth: 1)
+            )
+            .opacity(isInteractive || isSelected ? 1.0 : 0.4)
+        }
+        .buttonStyle(.plain)
+        .allowsHitTesting(isInteractive)
+    }
+}

--- a/CodeDump/Features/Onboarding/OnboardingPermissionsStep.swift
+++ b/CodeDump/Features/Onboarding/OnboardingPermissionsStep.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+import UserNotifications
+#if canImport(HealthKit)
+import HealthKit
+#endif
+
+struct OnboardingPermissionsStep: View {
+    @State private var healthGranted = false
+    @State private var notificationsGranted = false
+    @State private var healthRequested = false
+    @State private var notificationsRequested = false
+
+    var body: some View {
+        VStack(spacing: 24) {
+            // Header
+            VStack(spacing: 8) {
+                Image(systemName: "shield.checkered")
+                    .font(.system(size: 32))
+                    .foregroundColor(.outrunGreen)
+
+                Text("PERMISSIONS")
+                    .font(.outrunFuture(24))
+                    .foregroundColor(.white)
+
+                Text("These are optional but make the experience better.")
+                    .font(.outrunFuture(12))
+                    .foregroundColor(.white.opacity(0.5))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+            }
+
+            VStack(spacing: 16) {
+                // HealthKit
+                permissionRow(
+                    icon: "heart.fill",
+                    title: "APPLE HEALTH",
+                    detail: "Save workouts and read recovery data (sleep, HRV) for smarter recommendations.",
+                    color: .outrunPink,
+                    granted: healthGranted,
+                    requested: healthRequested
+                ) {
+                    await requestHealth()
+                }
+
+                // Notifications
+                permissionRow(
+                    icon: "bell.badge.fill",
+                    title: "NOTIFICATIONS",
+                    detail: "Get reminded about upcoming program workouts and rest day suggestions.",
+                    color: .outrunYellow,
+                    granted: notificationsGranted,
+                    requested: notificationsRequested
+                ) {
+                    await requestNotifications()
+                }
+            }
+            .padding(.horizontal, 24)
+        }
+    }
+
+    // MARK: - Permission Row
+
+    private func permissionRow(
+        icon: String,
+        title: String,
+        detail: String,
+        color: Color,
+        granted: Bool,
+        requested: Bool,
+        action: @escaping () async -> Void
+    ) -> some View {
+        HStack(spacing: 16) {
+            Image(systemName: icon)
+                .font(.system(size: 24))
+                .foregroundColor(color)
+                .frame(width: 40)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.outrunFuture(13))
+                    .foregroundColor(.white)
+
+                Text(detail)
+                    .font(.system(size: 12))
+                    .foregroundColor(.white.opacity(0.5))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+
+            if granted {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundColor(.outrunGreen)
+                    .font(.system(size: 22))
+            } else if requested {
+                Image(systemName: "minus.circle")
+                    .foregroundColor(.white.opacity(0.3))
+                    .font(.system(size: 22))
+            } else {
+                Button {
+                    Task { await action() }
+                } label: {
+                    Text("ALLOW")
+                        .font(.outrunFuture(10))
+                        .foregroundColor(.outrunBlack)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+                        .background(color)
+                        .cornerRadius(8)
+                }
+            }
+        }
+        .padding(16)
+        .background(Color.outrunSurface)
+        .cornerRadius(12)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(granted ? color.opacity(0.3) : Color.outrunPurple.opacity(0.3), lineWidth: 1)
+        )
+    }
+
+    // MARK: - Permission Requests
+
+    private func requestHealth() async {
+        #if os(iOS)
+        await HealthKitManager.shared.requestAuthorization()
+        healthRequested = true
+        healthGranted = HealthKitManager.shared.authorizationRequested
+        #endif
+    }
+
+    private func requestNotifications() async {
+        do {
+            let granted = try await UNUserNotificationCenter.current()
+                .requestAuthorization(options: [.alert, .sound, .badge])
+            notificationsRequested = true
+            notificationsGranted = granted
+        } catch {
+            notificationsRequested = true
+        }
+    }
+}

--- a/CodeDump/Features/Onboarding/OnboardingProgramStep.swift
+++ b/CodeDump/Features/Onboarding/OnboardingProgramStep.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+struct OnboardingProgramStep: View {
+    @Binding var selectedProgram: ProgramTemplate?
+    let userEquipment: Set<Equipment>
+
+    var body: some View {
+        VStack(spacing: 24) {
+            // Header
+            VStack(spacing: 8) {
+                Image(systemName: "calendar.badge.clock")
+                    .font(.system(size: 32))
+                    .foregroundColor(.outrunCyan)
+
+                Text("PICK A PROGRAM")
+                    .font(.outrunFuture(24))
+                    .foregroundColor(.white)
+
+                Text("Follow a structured plan, or skip and build your own.")
+                    .font(.outrunFuture(12))
+                    .foregroundColor(.white.opacity(0.5))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+            }
+
+            // Program list
+            ScrollView {
+                VStack(spacing: 12) {
+                    ForEach(ProgramTemplate.library, id: \.id) { program in
+                        programCard(program)
+                    }
+                }
+                .padding(.horizontal, 24)
+            }
+            .frame(maxHeight: 360)
+        }
+    }
+
+    // MARK: - Program Card
+
+    private func programCard(_ program: ProgramTemplate) -> some View {
+        let isSelected = selectedProgram?.id == program.id
+        let hasEquipment = program.requiredEquipment.isSubset(of: userEquipment)
+        let difficultyColor = difficultyDisplayColor(program.difficulty)
+
+        return Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                selectedProgram = isSelected ? nil : program
+            }
+        } label: {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text(program.name.uppercased())
+                        .font(.outrunFuture(14))
+                        .foregroundColor(isSelected ? .outrunCyan : .white)
+
+                    Spacer()
+
+                    if isSelected {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(.outrunCyan)
+                    }
+                }
+
+                Text(program.description)
+                    .font(.system(size: 13))
+                    .foregroundColor(.white.opacity(0.5))
+                    .lineLimit(2)
+
+                HStack(spacing: 12) {
+                    Label("\(program.daysPerWeek)x/wk", systemImage: "calendar")
+                    Label("\(program.durationWeeks) weeks", systemImage: "clock")
+                    Text(program.difficulty.displayName)
+                        .foregroundColor(difficultyColor)
+                }
+                .font(.outrunFuture(10))
+                .foregroundColor(.white.opacity(0.4))
+
+                if !hasEquipment {
+                    Label("Needs equipment you don't have", systemImage: "exclamationmark.triangle.fill")
+                        .font(.outrunFuture(9))
+                        .foregroundColor(.outrunOrange)
+                }
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(isSelected ? Color.outrunCyan.opacity(0.15) : Color.outrunSurface)
+            .cornerRadius(12)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(isSelected ? Color.outrunCyan : Color.outrunPurple.opacity(0.3), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func difficultyDisplayColor(_ difficulty: ProgramDifficulty) -> Color {
+        switch difficulty {
+        case .beginner:     return .outrunGreen
+        case .intermediate: return .outrunCyan
+        case .advanced:     return .outrunPink
+        }
+    }
+}

--- a/CodeDump/Features/Onboarding/OnboardingView.swift
+++ b/CodeDump/Features/Onboarding/OnboardingView.swift
@@ -1,97 +1,138 @@
 import SwiftUI
 
+// MARK: - Onboarding Step
+
+enum OnboardingStep: Int, CaseIterable {
+    case welcome
+    case equipment
+    case program
+    case permissions
+}
+
+// MARK: - Onboarding View
+
 struct OnboardingView: View {
     var onComplete: () -> Void
 
-    @State private var visibleFeature = 0
+    @State private var step: OnboardingStep = .welcome
+    @State private var selectedProgram: ProgramTemplate?
 
-    private let features: [(icon: String, title: String, body: String, color: Color)] = [
-        ("timer",            "INTERVAL TIMER",   "HIIT, strength, yoga, runs — fully customizable sets, rests, and exercises.", .outrunYellow),
-        ("lock.iphone",      "LIVE ACTIVITY",    "Your countdown lives on the lock screen and Dynamic Island so your phone stays in your pocket.", .outrunCyan),
-        ("applewatch",       "APPLE WATCH",      "Play, pause, and skip from your wrist while your phone tracks the session.", .outrunGreen),
-    ]
+    @AppStorage("equipmentProfile") private var equipmentRaw: String = EquipmentProfile.encode(EquipmentProfile.commercialGymEquipment)
+    @AppStorage("equipmentProfileConfigured") private var equipmentConfigured = false
+    @Environment(\.modelContext) private var modelContext
 
     var body: some View {
         ZStack {
             Color.outrunBlack.ignoresSafeArea()
-
-            // Grid lines — outrun road effect
             gridLines
 
             VStack(spacing: 0) {
-                Spacer()
-
-                // App name
-                VStack(spacing: 6) {
-                    Text("LAZER DRAGON")
-                        .font(.outrunFuture(36))
-                        .foregroundColor(.outrunYellow)
-                    Text("WORKOUT EXPERIENCE")
-                        .font(.outrunFuture(14))
-                        .foregroundColor(.outrunCyan)
-                        .kerning(4)
-                }
+                // Progress dots
+                progressIndicator
+                    .padding(.top, 16)
 
                 Spacer()
 
-                // Feature cards
-                TabView(selection: $visibleFeature) {
-                    ForEach(features.indices, id: \.self) { i in
-                        featureCard(features[i])
-                            .tag(i)
+                // Current step content
+                Group {
+                    switch step {
+                    case .welcome:
+                        OnboardingWelcomeStep()
+                    case .equipment:
+                        OnboardingEquipmentStep(
+                            equipmentRaw: $equipmentRaw
+                        )
+                    case .program:
+                        OnboardingProgramStep(
+                            selectedProgram: $selectedProgram,
+                            userEquipment: EquipmentProfile.decode(equipmentRaw)
+                        )
+                    case .permissions:
+                        OnboardingPermissionsStep()
                     }
                 }
-                .tabViewStyle(.page(indexDisplayMode: .always))
-                .frame(height: 220)
+                .transition(.asymmetric(
+                    insertion: .move(edge: .trailing).combined(with: .opacity),
+                    removal: .move(edge: .leading).combined(with: .opacity)
+                ))
 
                 Spacer()
 
-                // Get started
-                Button(action: onComplete) {
-                    Text("GET STARTED")
-                        .font(.outrunFuture(22))
-                        .foregroundColor(.outrunBlack)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 18)
-                        .background(Color.outrunCyan)
-                        .cornerRadius(12)
-                        .shadow(color: .outrunCyan.opacity(0.4), radius: 16)
-                }
-                .padding(.horizontal, 32)
-                .padding(.bottom, 52)
+                // Navigation buttons
+                bottomButtons
+                    .padding(.bottom, 52)
             }
         }
     }
 
-    // MARK: - Feature Card
+    // MARK: - Progress Indicator
 
-    private func featureCard(_ feature: (icon: String, title: String, body: String, color: Color)) -> some View {
-        VStack(spacing: 16) {
-            Image(systemName: feature.icon)
-                .font(.system(size: 36))
-                .foregroundColor(feature.color)
-
-            Text(feature.title)
-                .font(.outrunFuture(18))
-                .foregroundColor(.white)
-
-            Text(feature.body)
-                .font(.outrunFuture(13))
-                .foregroundColor(.white.opacity(0.55))
-                .multilineTextAlignment(.center)
-                .fixedSize(horizontal: false, vertical: true)
-                .padding(.horizontal, 16)
+    private var progressIndicator: some View {
+        HStack(spacing: 10) {
+            ForEach(OnboardingStep.allCases, id: \.rawValue) { s in
+                Capsule()
+                    .fill(s.rawValue <= step.rawValue ? Color.outrunCyan : Color.outrunPurple.opacity(0.4))
+                    .frame(width: s == step ? 24 : 8, height: 8)
+                    .animation(.easeInOut(duration: 0.25), value: step)
+            }
         }
-        .padding(.vertical, 24)
-        .padding(.horizontal, 24)
-        .frame(maxWidth: .infinity)
-        .background(Color.outrunSurface)
-        .cornerRadius(16)
-        .overlay(
-            RoundedRectangle(cornerRadius: 16)
-                .stroke(feature.color.opacity(0.3), lineWidth: 1)
-        )
+    }
+
+    // MARK: - Bottom Buttons
+
+    private var bottomButtons: some View {
+        VStack(spacing: 12) {
+            // Primary action
+            Button(action: advanceStep) {
+                Text(step == .permissions ? "LET'S GO" : "CONTINUE")
+                    .font(.outrunFuture(20))
+                    .foregroundColor(.outrunBlack)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+                    .background(Color.outrunCyan)
+                    .cornerRadius(12)
+                    .shadow(color: .outrunCyan.opacity(0.4), radius: 16)
+            }
+
+            // Skip (not on welcome or last step)
+            if step == .program {
+                Button(action: advanceStep) {
+                    Text("SKIP")
+                        .font(.outrunFuture(13))
+                        .foregroundColor(.white.opacity(0.4))
+                }
+            }
+        }
         .padding(.horizontal, 32)
+    }
+
+    // MARK: - Navigation
+
+    private func advanceStep() {
+        if step == .equipment {
+            equipmentConfigured = true
+        }
+
+        guard let next = OnboardingStep(rawValue: step.rawValue + 1) else {
+            // Final step — enroll in program if selected, then complete
+            if let program = selectedProgram {
+                enrollInProgram(program)
+            }
+            onComplete()
+            return
+        }
+
+        withAnimation(.easeInOut(duration: 0.3)) {
+            step = next
+        }
+    }
+
+    private func enrollInProgram(_ template: ProgramTemplate) {
+        let program = TrainingProgram(
+            programTemplateID: template.id,
+            durationWeeks: template.durationWeeks
+        )
+        modelContext.insert(program)
     }
 
     // MARK: - Grid Lines

--- a/CodeDump/Features/Onboarding/OnboardingWelcomeStep.swift
+++ b/CodeDump/Features/Onboarding/OnboardingWelcomeStep.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct OnboardingWelcomeStep: View {
+    @State private var visibleFeature = 0
+
+    private let features: [(icon: String, title: String, body: String, color: Color)] = [
+        ("timer",            "INTERVAL TIMER",   "HIIT, strength, yoga, runs — fully customizable sets, rests, and exercises.", .outrunYellow),
+        ("lock.iphone",      "LIVE ACTIVITY",    "Your countdown lives on the lock screen and Dynamic Island so your phone stays in your pocket.", .outrunCyan),
+        ("applewatch",       "APPLE WATCH",      "Play, pause, and skip from your wrist while your phone tracks the session.", .outrunGreen),
+    ]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // App name
+            VStack(spacing: 6) {
+                Text("LAZER DRAGON")
+                    .font(.outrunFuture(36))
+                    .foregroundColor(.outrunYellow)
+                Text("WORKOUT EXPERIENCE")
+                    .font(.outrunFuture(14))
+                    .foregroundColor(.outrunCyan)
+                    .kerning(4)
+            }
+
+            Spacer().frame(height: 40)
+
+            // Feature cards
+            TabView(selection: $visibleFeature) {
+                ForEach(features.indices, id: \.self) { i in
+                    featureCard(features[i])
+                        .tag(i)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .always))
+            .frame(height: 220)
+        }
+    }
+
+    private func featureCard(_ feature: (icon: String, title: String, body: String, color: Color)) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: feature.icon)
+                .font(.system(size: 36))
+                .foregroundColor(feature.color)
+
+            Text(feature.title)
+                .font(.outrunFuture(18))
+                .foregroundColor(.white)
+
+            Text(feature.body)
+                .font(.outrunFuture(13))
+                .foregroundColor(.white.opacity(0.55))
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.horizontal, 16)
+        }
+        .padding(.vertical, 24)
+        .padding(.horizontal, 24)
+        .frame(maxWidth: .infinity)
+        .background(Color.outrunSurface)
+        .cornerRadius(16)
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(feature.color.opacity(0.3), lineWidth: 1)
+        )
+        .padding(.horizontal, 32)
+    }
+}


### PR DESCRIPTION
## Summary
- Replace 3-slide feature carousel with a 4-step guided onboarding flow
- Steps: Welcome → Equipment setup → Program picker (skippable) → Permissions (HealthKit + notifications)
- Equipment step writes to same `@AppStorage("equipmentProfile")` used by settings
- Program step enrolls user in SwiftData `TrainingProgram` on completion
- Permissions step uses explain-first pattern with individual ALLOW buttons

## Test plan
- [ ] Fresh install: verify onboarding appears and all 4 steps work
- [ ] Equipment presets (Home/Commercial/Custom) populate grid correctly
- [ ] Program selection shows equipment mismatch warning when applicable
- [ ] Skipping program step works without crash
- [ ] HealthKit and notification permission dialogs appear on ALLOW tap
- [ ] After completion, main app loads and selected program is enrolled
- [ ] Existing users (`hasCompletedOnboarding = true`) skip onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)