### PR TITLE
Add analytics dashboard with charts

### DIFF
--- a/CodeDump/Features/Analytics/AnalyticsDashboardView.swift
+++ b/CodeDump/Features/Analytics/AnalyticsDashboardView.swift
@@ -1,0 +1,289 @@
+import SwiftUI
+import SwiftData
+import Charts
+
+struct AnalyticsDashboardView: View {
+    @State private var viewModel = AnalyticsViewModel()
+    @Query(sort: \WorkoutSession.date, order: .reverse) private var sessions: [WorkoutSession]
+    @Query(sort: \SetLog.date, order: .reverse) private var allLogs: [SetLog]
+
+    var body: some View {
+        ZStack {
+            Color.outrunBackground.ignoresSafeArea()
+
+            ScrollView {
+                VStack(spacing: 20) {
+                    rangePicker
+                    statsRow
+                    volumeChartSection
+                    muscleDistributionSection
+                    exerciseProgressSection
+                }
+                .padding(.horizontal, 16)
+                .padding(.bottom, 24)
+            }
+        }
+        .navigationTitle("ANALYTICS")
+        .navigationBarTitleDisplayMode(.inline)
+        .outrunNavBar()
+        .onAppear { viewModel.refresh(sessions: sessions, allLogs: allLogs) }
+        .onChange(of: viewModel.range) { viewModel.refresh(sessions: sessions, allLogs: allLogs) }
+    }
+
+    // MARK: - Range Picker
+
+    private var rangePicker: some View {
+        HStack(spacing: 4) {
+            ForEach(AnalyticsRange.allCases) { range in
+                Button {
+                    viewModel.range = range
+                } label: {
+                    Text(range.rawValue)
+                        .font(.outrunFuture(12))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                        .background(viewModel.range == range ? Color.outrunCyan.opacity(0.3) : Color.outrunBlack)
+                        .foregroundColor(viewModel.range == range ? .outrunCyan : .white.opacity(0.4))
+                        .cornerRadius(8)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.top, 8)
+    }
+
+    // MARK: - Stats Row
+
+    private var statsRow: some View {
+        HStack(spacing: 12) {
+            statCard(value: "\(viewModel.totalSessions)", label: "SESSIONS", color: .outrunCyan)
+            statCard(value: SessionAnalytics.formatVolume(viewModel.totalVolume), label: "VOLUME", color: .outrunYellow)
+            statCard(value: "\(viewModel.totalPRs)", label: "PRs", color: .outrunPink)
+            statCard(value: "\(viewModel.currentStreak)", label: "STREAK", color: .outrunGreen)
+        }
+    }
+
+    private func statCard(value: String, label: String, color: Color) -> some View {
+        VStack(spacing: 4) {
+            Text(value)
+                .font(.outrunFuture(20))
+                .foregroundColor(color)
+            Text(label)
+                .font(.outrunFuture(9))
+                .foregroundColor(.white.opacity(0.4))
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 14)
+        .background(Color.outrunSurface)
+        .cornerRadius(12)
+    }
+
+    // MARK: - Volume Chart
+
+    private var volumeChartSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionHeader("WEEKLY VOLUME")
+
+            if viewModel.weeklyVolumes.isEmpty {
+                emptyState("Complete a workout to see volume trends")
+            } else {
+                Chart(viewModel.weeklyVolumes) { week in
+                    BarMark(
+                        x: .value("Week", week.weekStart, unit: .weekOfYear),
+                        y: .value("Volume", week.volume)
+                    )
+                    .foregroundStyle(Color.outrunCyan.gradient)
+                    .cornerRadius(4)
+                }
+                .chartYAxis {
+                    AxisMarks(position: .leading) { value in
+                        AxisValueLabel {
+                            if let v = value.as(Double.self) {
+                                Text(SessionAnalytics.formatVolume(v))
+                                    .font(.system(size: 10))
+                                    .foregroundColor(.white.opacity(0.4))
+                            }
+                        }
+                        AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5, dash: [4]))
+                            .foregroundStyle(Color.outrunPurple.opacity(0.3))
+                    }
+                }
+                .chartXAxis {
+                    AxisMarks(values: .stride(by: .weekOfYear)) { value in
+                        AxisValueLabel(format: .dateTime.month(.abbreviated).day(), centered: true)
+                            .font(.system(size: 9))
+                            .foregroundStyle(.white.opacity(0.4))
+                    }
+                }
+                .chartPlotStyle { plot in
+                    plot.background(Color.outrunBlack.opacity(0.3))
+                }
+                .frame(height: 200)
+            }
+        }
+        .padding(16)
+        .background(Color.outrunSurface)
+        .cornerRadius(12)
+    }
+
+    // MARK: - Muscle Distribution
+
+    private var muscleDistributionSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionHeader("MUSCLE DISTRIBUTION")
+
+            if viewModel.muscleDistribution.isEmpty {
+                emptyState("Log sets to see muscle group breakdown")
+            } else {
+                Chart(viewModel.muscleDistribution) { item in
+                    BarMark(
+                        x: .value("Sets", item.sets),
+                        y: .value("Muscle", item.muscle.displayName)
+                    )
+                    .foregroundStyle(muscleColor(item.muscle).gradient)
+                    .cornerRadius(4)
+                    .annotation(position: .trailing, spacing: 4) {
+                        Text("\(item.sets)")
+                            .font(.outrunFuture(10))
+                            .foregroundColor(.white.opacity(0.5))
+                    }
+                }
+                .chartXAxis(.hidden)
+                .chartYAxis {
+                    AxisMarks { value in
+                        AxisValueLabel()
+                            .font(.system(size: 11))
+                            .foregroundStyle(.white.opacity(0.6))
+                    }
+                }
+                .chartPlotStyle { plot in
+                    plot.background(Color.outrunBlack.opacity(0.3))
+                }
+                .frame(height: CGFloat(viewModel.muscleDistribution.count) * 32 + 16)
+            }
+        }
+        .padding(16)
+        .background(Color.outrunSurface)
+        .cornerRadius(12)
+    }
+
+    // MARK: - Exercise Progress
+
+    private var exerciseProgressSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionHeader("EXERCISE PROGRESS")
+
+            if viewModel.exerciseNames.isEmpty {
+                emptyState("Log weighted sets to track exercise progress")
+            } else {
+                // Exercise picker
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(viewModel.exerciseNames, id: \.self) { name in
+                            let id = viewModel.exerciseID(forName: name, logs: allLogs)
+                            let isSelected = id == viewModel.selectedExerciseID
+                            Button {
+                                viewModel.selectedExerciseID = id
+                                viewModel.computeExercisePRTimeline(exerciseTemplateID: id ?? name, allLogs: allLogs)
+                            } label: {
+                                Text(name.uppercased())
+                                    .font(.outrunFuture(9))
+                                    .padding(.horizontal, 12)
+                                    .padding(.vertical, 6)
+                                    .background(isSelected ? Color.outrunPink.opacity(0.3) : Color.outrunBlack)
+                                    .foregroundColor(isSelected ? .outrunPink : .white.opacity(0.4))
+                                    .cornerRadius(6)
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 6)
+                                            .stroke(isSelected ? Color.outrunPink : .clear, lineWidth: 1)
+                                    )
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+
+                // PR timeline chart
+                if viewModel.exercisePRTimeline.isEmpty {
+                    emptyState("No weight data for this exercise")
+                } else {
+                    Chart(viewModel.exercisePRTimeline) { point in
+                        LineMark(
+                            x: .value("Date", point.date),
+                            y: .value("Weight", point.weight)
+                        )
+                        .foregroundStyle(Color.outrunPink)
+                        .interpolationMethod(.catmullRom)
+                        .lineStyle(StrokeStyle(lineWidth: 2))
+
+                        PointMark(
+                            x: .value("Date", point.date),
+                            y: .value("Weight", point.weight)
+                        )
+                        .foregroundStyle(Color.outrunPink)
+                        .symbolSize(30)
+                    }
+                    .chartYAxis {
+                        AxisMarks(position: .leading) { value in
+                            AxisValueLabel {
+                                if let v = value.as(Double.self) {
+                                    Text("\(Int(v))lb")
+                                        .font(.system(size: 10))
+                                        .foregroundColor(.white.opacity(0.4))
+                                }
+                            }
+                            AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5, dash: [4]))
+                                .foregroundStyle(Color.outrunPurple.opacity(0.3))
+                        }
+                    }
+                    .chartXAxis {
+                        AxisMarks { value in
+                            AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                                .font(.system(size: 9))
+                                .foregroundStyle(.white.opacity(0.4))
+                        }
+                    }
+                    .chartPlotStyle { plot in
+                        plot.background(Color.outrunBlack.opacity(0.3))
+                    }
+                    .frame(height: 200)
+                }
+            }
+        }
+        .padding(16)
+        .background(Color.outrunSurface)
+        .cornerRadius(12)
+    }
+
+    // MARK: - Helpers
+
+    private func sectionHeader(_ text: String) -> some View {
+        Text(text)
+            .font(.outrunFuture(13))
+            .foregroundColor(.outrunCyan)
+    }
+
+    private func emptyState(_ message: String) -> some View {
+        Text(message)
+            .font(.outrunFuture(11))
+            .foregroundColor(.white.opacity(0.3))
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 40)
+    }
+
+    private func muscleColor(_ muscle: MuscleGroup) -> Color {
+        switch muscle {
+        case .chest:      return .outrunPink
+        case .back:       return .outrunCyan
+        case .shoulders:  return .outrunYellow
+        case .biceps:     return .outrunGreen
+        case .triceps:    return .outrunOrange
+        case .quads:      return .outrunCyan
+        case .hamstrings: return .outrunPink
+        case .glutes:     return .outrunYellow
+        case .calves:     return .outrunGreen
+        case .core:       return .outrunOrange
+        case .fullBody:   return .outrunCyan
+        }
+    }
+}

--- a/CodeDump/Features/Analytics/AnalyticsViewModel.swift
+++ b/CodeDump/Features/Analytics/AnalyticsViewModel.swift
@@ -1,0 +1,229 @@
+import SwiftUI
+import SwiftData
+
+// MARK: - Time Range
+
+enum AnalyticsRange: String, CaseIterable, Identifiable {
+    case oneWeek  = "1W"
+    case oneMonth = "1M"
+    case threeMonths = "3M"
+    case all = "ALL"
+
+    var id: String { rawValue }
+
+    var days: Int? {
+        switch self {
+        case .oneWeek:      return 7
+        case .oneMonth:     return 30
+        case .threeMonths:  return 90
+        case .all:          return nil
+        }
+    }
+}
+
+// MARK: - Chart Data Points
+
+struct WeeklyVolume: Identifiable {
+    let id = UUID()
+    let weekStart: Date
+    let volume: Double
+    let sets: Int
+    let sessions: Int
+}
+
+struct ExercisePRPoint: Identifiable {
+    let id = UUID()
+    let date: Date
+    let weight: Double
+    let reps: Int
+    let exerciseName: String
+}
+
+struct MuscleDistribution: Identifiable {
+    let id = UUID()
+    let muscle: MuscleGroup
+    let sets: Int
+    let percentage: Double
+}
+
+// MARK: - View Model
+
+@Observable
+@MainActor
+final class AnalyticsViewModel {
+    var range: AnalyticsRange = .oneMonth
+
+    var weeklyVolumes: [WeeklyVolume] = []
+    var muscleDistribution: [MuscleDistribution] = []
+    var exerciseNames: [String] = []
+    var selectedExerciseID: String?
+    var exercisePRTimeline: [ExercisePRPoint] = []
+
+    var totalSessions: Int = 0
+    var totalVolume: Double = 0
+    var totalPRs: Int = 0
+    var currentStreak: Int = 0
+
+    private let analyzer = MuscleAnalyzer()
+
+    func refresh(sessions: [WorkoutSession], allLogs: [SetLog]) {
+        let cutoff = cutoffDate
+        let filtered = sessions.filter { cutoff == nil || $0.date >= cutoff! }
+        let filteredLogs = allLogs.filter { cutoff == nil || $0.date >= cutoff! }
+
+        computeStats(sessions: filtered, logs: filteredLogs)
+        computeWeeklyVolumes(sessions: filtered)
+        computeMuscleDistribution(logs: filteredLogs)
+        computeExerciseList(logs: filteredLogs)
+
+        if let selected = selectedExerciseID {
+            computeExercisePRTimeline(exerciseTemplateID: selected, allLogs: allLogs)
+        }
+
+        computeStreak(sessions: sessions)
+    }
+
+    var cutoffDate: Date? {
+        guard let days = range.days else { return nil }
+        return Calendar.current.date(byAdding: .day, value: -days, to: .now)
+    }
+
+    // MARK: - Stats
+
+    private func computeStats(sessions: [WorkoutSession], logs: [SetLog]) {
+        totalSessions = sessions.count
+        totalVolume = logs.reduce(0.0) { $0 + ($1.weight ?? 0) * Double($1.reps ?? 0) }
+
+        // Count PRs by finding max weight per exercise template across time
+        var prCount = 0
+        let byExercise = Dictionary(grouping: logs.filter { $0.weight != nil }) { $0.exerciseTemplateID ?? $0.exerciseName }
+        for (_, exerciseLogs) in byExercise {
+            let sorted = exerciseLogs.sorted { $0.date < $1.date }
+            var maxWeight: Double = 0
+            for log in sorted {
+                let w = log.weight ?? 0
+                if w > maxWeight {
+                    if maxWeight > 0 { prCount += 1 }
+                    maxWeight = w
+                }
+            }
+        }
+        totalPRs = prCount
+    }
+
+    // MARK: - Weekly Volume
+
+    private func computeWeeklyVolumes(sessions: [WorkoutSession]) {
+        let calendar = Calendar.current
+
+        var weekMap: [Date: (volume: Double, sets: Int, sessions: Int)] = [:]
+        for session in sessions {
+            let weekStart = calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: session.date)) ?? session.date
+            var entry = weekMap[weekStart] ?? (0, 0, 0)
+            for log in session.setLogs {
+                entry.volume += (log.weight ?? 0) * Double(log.reps ?? 0)
+                entry.sets += 1
+            }
+            entry.sessions += 1
+            weekMap[weekStart] = entry
+        }
+
+        weeklyVolumes = weekMap
+            .map { WeeklyVolume(weekStart: $0.key, volume: $0.value.volume, sets: $0.value.sets, sessions: $0.value.sessions) }
+            .sorted { $0.weekStart < $1.weekStart }
+    }
+
+    // MARK: - Muscle Distribution
+
+    private func computeMuscleDistribution(logs: [SetLog]) {
+        var counts: [MuscleGroup: Int] = [:]
+        for log in logs {
+            for muscle in analyzer.musclesForLog(log) {
+                counts[muscle, default: 0] += 1
+            }
+        }
+        let total = max(1, counts.values.reduce(0, +))
+        muscleDistribution = counts
+            .map { MuscleDistribution(muscle: $0.key, sets: $0.value, percentage: Double($0.value) / Double(total) * 100) }
+            .sorted { $0.sets > $1.sets }
+    }
+
+    // MARK: - Exercise List
+
+    private func computeExerciseList(logs: [SetLog]) {
+        var seen: Set<String> = []
+        var names: [(name: String, id: String)] = []
+        for log in logs {
+            let id = log.exerciseTemplateID ?? log.exerciseName
+            if !seen.contains(id) {
+                seen.insert(id)
+                names.append((log.exerciseName, id))
+            }
+        }
+        exerciseNames = names.map(\.name)
+        if selectedExerciseID == nil, let first = names.first {
+            selectedExerciseID = first.id
+        }
+    }
+
+    // MARK: - Exercise PR Timeline
+
+    func computeExercisePRTimeline(exerciseTemplateID: String, allLogs: [SetLog]) {
+        let relevant = allLogs
+            .filter { ($0.exerciseTemplateID ?? $0.exerciseName) == exerciseTemplateID && $0.weight != nil }
+            .sorted { $0.date < $1.date }
+
+        var timeline: [ExercisePRPoint] = []
+        var maxWeight: Double = 0
+
+        for log in relevant {
+            let w = log.weight ?? 0
+            if w >= maxWeight {
+                maxWeight = w
+                timeline.append(ExercisePRPoint(
+                    date: log.date,
+                    weight: w,
+                    reps: log.reps ?? 0,
+                    exerciseName: log.exerciseName
+                ))
+            }
+        }
+
+        exercisePRTimeline = timeline
+    }
+
+    // MARK: - Streak
+
+    private func computeStreak(sessions: [WorkoutSession]) {
+        let calendar = Calendar.current
+        let sortedDays = Set(sessions.map { calendar.startOfDay(for: $0.date) }).sorted(by: >)
+        guard let mostRecent = sortedDays.first else {
+            currentStreak = 0
+            return
+        }
+
+        // Only count streak if most recent session was today or yesterday
+        let daysSinceLast = calendar.dateComponents([.day], from: mostRecent, to: calendar.startOfDay(for: .now)).day ?? 0
+        guard daysSinceLast <= 1 else {
+            currentStreak = 0
+            return
+        }
+
+        var streak = 1
+        for i in 1..<sortedDays.count {
+            let gap = calendar.dateComponents([.day], from: sortedDays[i], to: sortedDays[i - 1]).day ?? 0
+            if gap <= 1 {
+                streak += 1
+            } else {
+                break
+            }
+        }
+        currentStreak = streak
+    }
+
+    // MARK: - Exercise Picker Helpers
+
+    func exerciseID(forName name: String, logs: [SetLog]) -> String? {
+        logs.first { $0.exerciseName == name }?.exerciseTemplateID ?? name
+    }
+}

--- a/CodeDump/Features/Body/BodyStatusView.swift
+++ b/CodeDump/Features/Body/BodyStatusView.swift
@@ -39,6 +39,14 @@ struct BodyStatusView: View {
         .navigationTitle("BODY")
         .navigationBarTitleDisplayMode(.large)
         .outrunNavBar()
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                NavigationLink(destination: AnalyticsDashboardView()) {
+                    Image(systemName: "chart.xyaxis.line")
+                        .foregroundColor(.outrunCyan)
+                }
+            }
+        }
         .onAppear { refresh() }
         .onChange(of: sessions.count) { refresh() }
         #if os(iOS)


### PR DESCRIPTION
## Summary
- Add analytics dashboard accessible via chart icon in BODY tab toolbar
- Time range picker (1W/1M/3M/ALL) filters all chart data
- Stats row showing sessions, total volume, PRs, and current streak
- Weekly volume bar chart using Swift Charts
- Muscle distribution horizontal bar chart by set count
- Exercise progress line chart showing PR weight timeline with exercise picker

## Test plan
- [ ] Navigate to BODY tab → tap chart icon → analytics dashboard loads
- [ ] Time range picker filters data correctly across all sections
- [ ] Empty states show when no data exists
- [ ] Volume chart renders weekly bars with formatted Y-axis (K/M suffixes)
- [ ] Muscle distribution shows correct set counts per muscle group
- [ ] Exercise picker scrolls horizontally, selection updates PR chart
- [ ] PR timeline shows weight progression with point markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)