### PR TITLE
Polish Apple Watch companion app

### DIFF
--- a/CodeDump/AppDelegate.swift
+++ b/CodeDump/AppDelegate.swift
@@ -64,6 +64,7 @@ struct RootView: View {
     @State private var workoutsPath = NavigationPath()
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
     @Environment(\.modelContext) private var modelContext
+    @Query(sort: \WorkoutSession.date, order: .reverse) private var recentSessions: [WorkoutSession]
     @State private var importedWorkout: WorkoutExport?
     @State private var showingImportAlert = false
     @State private var importError: String?
@@ -104,6 +105,7 @@ struct RootView: View {
         .onAppear {
             styleTabBar()
             WidgetDataProvider.shared.refreshAll(context: modelContext)
+            WatchConnectivityManager.shared.sendIdleContext(lastWorkoutDate: recentSessions.first?.date)
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
             WidgetDataProvider.shared.refreshAll(context: modelContext)

--- a/CodeDump/Features/WorkoutSession/WatchConnectivityManager.swift
+++ b/CodeDump/Features/WorkoutSession/WatchConnectivityManager.swift
@@ -33,6 +33,17 @@ final class WatchConnectivityManager: NSObject {
             WCSession.default.sendMessage(payload, replyHandler: nil)
         }
     }
+
+    /// Sends idle context (no active workout) with the last workout date
+    /// so the Watch idle screen can show when the user last trained.
+    func sendIdleContext(lastWorkoutDate: Date?) {
+        guard WCSession.default.activationState == .activated else { return }
+        var context: [String: Any] = ["workoutActive": false]
+        if let date = lastWorkoutDate {
+            context["lastWorkoutDate"] = date.timeIntervalSince1970
+        }
+        try? WCSession.default.updateApplicationContext(context)
+    }
 }
 
 // MARK: - WCSessionDelegate

--- a/CodeDump/Features/WorkoutSession/WorkoutSessionViewModel.swift
+++ b/CodeDump/Features/WorkoutSession/WorkoutSessionViewModel.swift
@@ -398,6 +398,7 @@ final class WorkoutSessionViewModel {
         [
             "phaseTitle": phaseTitle,
             "setLabel": setLabel,
+            "exerciseName": currentExercise?.name ?? "",
             "splitDuration": splitDuration,
             "isRunning": isRunning,
             "workoutActive": phase != .idle && phase != .completed,

--- a/LDWEWatch Extension/WatchConnectivityManager.swift
+++ b/LDWEWatch Extension/WatchConnectivityManager.swift
@@ -9,10 +9,12 @@ final class WatchConnectivityManager: NSObject, ObservableObject {
     @Published var workoutActive: Bool = false
     @Published var phaseTitle: String = "WAITING"
     @Published var setLabel: String = ""
+    @Published var exerciseName: String = ""
     @Published var splitTimeRemaining: Int = 0
     @Published var splitDuration: Int = 1
     @Published var totalElapsed: Int = 0
     @Published var isRunning: Bool = false
+    @Published var lastWorkoutDate: Date?
 
     // Reference timestamps from the iPhone
     private var phaseStartDate: Date = .distantPast
@@ -61,6 +63,7 @@ final class WatchConnectivityManager: NSObject, ObservableObject {
         if let v = context["workoutActive"] as? Bool   { workoutActive = v }
         if let v = context["phaseTitle"]    as? String { phaseTitle = v }
         if let v = context["setLabel"]      as? String { setLabel = v }
+        if let v = context["exerciseName"]  as? String { exerciseName = v }
         if let v = context["splitDuration"] as? Int    { splitDuration = v }
 
         if let v = context["phaseStartDate"] as? TimeInterval {
@@ -71,6 +74,9 @@ final class WatchConnectivityManager: NSObject, ObservableObject {
         }
         if let v = context["totalPausedTime"] as? TimeInterval {
             totalPausedTime = v
+        }
+        if let v = context["lastWorkoutDate"] as? TimeInterval {
+            lastWorkoutDate = Date(timeIntervalSince1970: v)
         }
 
         if let v = context["isRunning"] as? Bool {

--- a/LDWEWatch Extension/WatchSessionView.swift
+++ b/LDWEWatch Extension/WatchSessionView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WatchKit
 
 struct WatchSessionView: View {
     @EnvironmentObject var connectivity: WatchConnectivityManager
@@ -12,12 +13,22 @@ struct WatchSessionView: View {
             }
         }
         .background(.black)
+        .onChange(of: connectivity.phaseTitle) {
+            WKInterfaceDevice.current().play(.notification)
+        }
+        .onChange(of: connectivity.workoutActive) {
+            if connectivity.workoutActive {
+                WKInterfaceDevice.current().play(.start)
+            } else {
+                WKInterfaceDevice.current().play(.success)
+            }
+        }
     }
 
     // MARK: - Idle
 
     private var idleView: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: 10) {
             Image(systemName: "flame.fill")
                 .font(.system(size: 36))
                 .foregroundColor(.cyan)
@@ -26,10 +37,23 @@ struct WatchSessionView: View {
                 .font(.system(size: 14, weight: .bold, design: .monospaced))
                 .foregroundColor(.yellow)
 
-            Text("Start a workout on\nyour iPhone to see\nprogress here.")
-                .font(.system(size: 12))
-                .foregroundColor(.white.opacity(0.6))
-                .multilineTextAlignment(.center)
+            if let lastDate = connectivity.lastWorkoutDate {
+                Text("Last workout")
+                    .font(.system(size: 11))
+                    .foregroundColor(.white.opacity(0.4))
+                Text(lastDate, style: .relative)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.cyan.opacity(0.8))
+                    + Text(" ago")
+                    .font(.system(size: 12))
+                    .foregroundColor(.cyan.opacity(0.8))
+            }
+
+            Spacer().frame(height: 4)
+
+            Label("START ON iPHONE", systemImage: "iphone")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(.white.opacity(0.5))
         }
         .padding()
     }
@@ -38,12 +62,22 @@ struct WatchSessionView: View {
 
     private var sessionView: some View {
         VStack(spacing: 6) {
-            // Phase title
-            Text(connectivity.phaseTitle)
-                .font(.system(size: 18, weight: .bold, design: .monospaced))
-                .foregroundColor(.yellow)
-                .lineLimit(1)
-                .minimumScaleFactor(0.5)
+            // Phase title + exercise name
+            VStack(spacing: 2) {
+                Text(connectivity.phaseTitle)
+                    .font(.system(size: 18, weight: .bold, design: .monospaced))
+                    .foregroundColor(.yellow)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.5)
+
+                if !connectivity.exerciseName.isEmpty {
+                    Text(connectivity.exerciseName)
+                        .font(.system(size: 11))
+                        .foregroundColor(.white.opacity(0.6))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.6)
+                }
+            }
 
             // Progress ring with countdown
             ZStack {
@@ -60,30 +94,45 @@ struct WatchSessionView: View {
             }
             .frame(width: 70, height: 70)
 
-            // Set label
-            if !connectivity.setLabel.isEmpty {
-                Text(connectivity.setLabel)
-                    .font(.system(size: 11))
-                    .foregroundColor(.secondary)
+            // Set label + total elapsed
+            HStack {
+                if !connectivity.setLabel.isEmpty {
+                    Text(connectivity.setLabel)
+                        .font(.system(size: 11))
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+                Text(formattedTotalElapsed)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.4))
             }
 
             // Controls
             HStack(spacing: 20) {
-                Button { connectivity.sendAction("skipBack") } label: {
+                Button {
+                    connectivity.sendAction("skipBack")
+                    WKInterfaceDevice.current().play(.click)
+                } label: {
                     Image(systemName: "backward.fill")
                         .font(.system(size: 14))
                 }
                 .buttonStyle(.plain)
                 .foregroundColor(.white)
 
-                Button { connectivity.sendAction("playPause") } label: {
+                Button {
+                    connectivity.sendAction("playPause")
+                    WKInterfaceDevice.current().play(.click)
+                } label: {
                     Image(systemName: connectivity.isRunning ? "pause.fill" : "play.fill")
                         .font(.system(size: 18))
                 }
                 .buttonStyle(.plain)
                 .foregroundColor(.cyan)
 
-                Button { connectivity.sendAction("skipForward") } label: {
+                Button {
+                    connectivity.sendAction("skipForward")
+                    WKInterfaceDevice.current().play(.click)
+                } label: {
                     Image(systemName: "forward.fill")
                         .font(.system(size: 14))
                 }
@@ -102,6 +151,13 @@ struct WatchSessionView: View {
 
     private var formattedTime: String {
         let t = max(0, connectivity.splitTimeRemaining)
+        let m = t / 60
+        let s = t % 60
+        return String(format: "%d:%02d", m, s)
+    }
+
+    private var formattedTotalElapsed: String {
+        let t = max(0, connectivity.totalElapsed)
         let m = t / 60
         let s = t % 60
         return String(format: "%d:%02d", m, s)


### PR DESCRIPTION
## Summary
- Add haptic feedback on phase transitions (`.notification`), play/pause (`.click`), workout start (`.start`) and end (`.success`)
- Display current exercise name in Watch session view
- Show total elapsed time alongside set label
- Enhanced idle screen showing last workout date and "START ON iPHONE" prompt
- Send `exerciseName` and `lastWorkoutDate` in Watch connectivity payload

## Test plan
- [ ] Start workout on iPhone → Watch shows exercise name below phase title
- [ ] Phase transition → Watch plays haptic notification
- [ ] Tap play/pause/skip → subtle click haptic fires
- [ ] Workout ends → success haptic plays
- [ ] Open Watch app with no active workout → shows last workout date
- [ ] Fresh install with no sessions → idle screen shows "START ON iPHONE" without date

🤖 Generated with [Claude Code](https://claude.com/claude-code)