### PR TITLE
Add Program Progress widget and targeted refreshes

### DIFF
--- a/CodeDump.xcodeproj/project.pbxproj
+++ b/CodeDump.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		A1B2C30100000009000001A1 /* WeeklyStreakWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3010000000A000001A1 /* WeeklyStreakWidget.swift */; };
 		A1B2C3010000000B000001A1 /* MuscleHeatmapWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3010000000C000001A1 /* MuscleHeatmapWidget.swift */; };
 		A1B2C3010000000D000001A1 /* PRCelebrationWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3010000000E000001A1 /* PRCelebrationWidget.swift */; };
+		A1B2C30100000020000001A1 /* ProgramProgressWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C30100000021000001A1 /* ProgramProgressWidget.swift */; };
 		A1B2C3010000000F000001A1 /* OutrunFuture.otf in Resources */ = {isa = PBXBuildFile; fileRef = D52114C62466377E00D1F0ED /* OutrunFuture.otf */; };
 		A1B2C30100000010000001A1 /* OutrunFutureBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = D52114C42466377D00D1F0ED /* OutrunFutureBold.otf */; };
 		A1B2C30100000011000001A1 /* OutrunFutureBoldItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = D52114C52466377E00D1F0ED /* OutrunFutureBoldItalic.otf */; };
@@ -125,6 +126,7 @@
 		A1B2C3010000000A000001A1 /* WeeklyStreakWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyStreakWidget.swift; sourceTree = "<group>"; };
 		A1B2C3010000000C000001A1 /* MuscleHeatmapWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleHeatmapWidget.swift; sourceTree = "<group>"; };
 		A1B2C3010000000E000001A1 /* PRCelebrationWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRCelebrationWidget.swift; sourceTree = "<group>"; };
+		A1B2C30100000021000001A1 /* ProgramProgressWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramProgressWidget.swift; sourceTree = "<group>"; };
 		A1B2C30100000012000001A1 /* LDWELiveActivity.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LDWELiveActivity.entitlements; sourceTree = "<group>"; };
 		A3E070372F60A6AF003EF4CD /* ActivityKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ActivityKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.2.sdk/System/iOSSupport/System/Library/Frameworks/ActivityKit.framework; sourceTree = DEVELOPER_DIR; };
 		A42D196B4C0F424CA36542CB /* WorkoutLiveActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutLiveActivityView.swift; sourceTree = "<group>"; };
@@ -259,6 +261,7 @@
 				A1B2C3010000000A000001A1 /* WeeklyStreakWidget.swift */,
 				A1B2C3010000000C000001A1 /* MuscleHeatmapWidget.swift */,
 				A1B2C3010000000E000001A1 /* PRCelebrationWidget.swift */,
+				A1B2C30100000021000001A1 /* ProgramProgressWidget.swift */,
 				42E3AD6526014BF48CB225A8 /* Info.plist */,
 			);
 			path = LDWELiveActivity;
@@ -650,6 +653,7 @@
 				A1B2C30100000009000001A1 /* WeeklyStreakWidget.swift in Sources */,
 				A1B2C3010000000B000001A1 /* MuscleHeatmapWidget.swift in Sources */,
 				A1B2C3010000000D000001A1 /* PRCelebrationWidget.swift in Sources */,
+				A1B2C30100000020000001A1 /* ProgramProgressWidget.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CodeDump/Features/Widgets/WidgetDataProvider.swift
+++ b/CodeDump/Features/Widgets/WidgetDataProvider.swift
@@ -39,6 +39,16 @@ struct PRCelebrationData: Codable {
     }
 }
 
+struct ProgramProgressData: Codable {
+    let programName: String
+    let currentWeek: Int
+    let totalWeeks: Int
+    let completedDays: Int
+    let totalDays: Int
+    let percentage: Double
+    let updatedAt: Date
+}
+
 // MARK: - Widget Data Provider
 
 /// Bridges SwiftData models to the shared App Group UserDefaults
@@ -64,15 +74,45 @@ final class WidgetDataProvider {
 
     // MARK: - Refresh All
 
+    // MARK: - Widget Kind Constants
+
+    static let nextWorkoutKind     = "NextWorkoutWidget"
+    static let weeklyStreakKind    = "WeeklyStreakWidget"
+    static let muscleHeatmapKind  = "MuscleHeatmapWidget"
+    static let prCelebrationKind  = "PRCelebrationWidget"
+    static let programProgressKind = "ProgramProgressWidget"
+
     /// Refreshes all widget data from the current SwiftData context.
     func refreshAll(context: ModelContext) {
         refreshNextWorkout(context: context)
         refreshWeeklyStreak(context: context)
         refreshMuscleHeatmap(context: context)
         refreshPRCelebration(context: context)
+        refreshProgramProgress(context: context)
 
-        // Tell WidgetKit to refresh all timelines
         WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    /// Refreshes only workout-completion-relevant widgets (streak, heatmap, PR, program).
+    func refreshAfterWorkout(context: ModelContext) {
+        refreshWeeklyStreak(context: context)
+        refreshMuscleHeatmap(context: context)
+        refreshPRCelebration(context: context)
+        refreshProgramProgress(context: context)
+
+        WidgetCenter.shared.reloadTimelines(ofKind: Self.weeklyStreakKind)
+        WidgetCenter.shared.reloadTimelines(ofKind: Self.muscleHeatmapKind)
+        WidgetCenter.shared.reloadTimelines(ofKind: Self.prCelebrationKind)
+        WidgetCenter.shared.reloadTimelines(ofKind: Self.programProgressKind)
+    }
+
+    /// Refreshes only program-related widgets (next workout, program progress).
+    func refreshAfterProgramChange(context: ModelContext) {
+        refreshNextWorkout(context: context)
+        refreshProgramProgress(context: context)
+
+        WidgetCenter.shared.reloadTimelines(ofKind: Self.nextWorkoutKind)
+        WidgetCenter.shared.reloadTimelines(ofKind: Self.programProgressKind)
     }
 
     // MARK: - Next Workout
@@ -262,6 +302,36 @@ final class WidgetDataProvider {
             achievedAt: latestPR.date
         )
         write(data, forKey: "widget.prCelebration")
+    }
+
+    // MARK: - Program Progress
+
+    func refreshProgramProgress(context: ModelContext) {
+        let descriptor = FetchDescriptor<TrainingProgram>(
+            predicate: #Predicate { $0.isActive }
+        )
+        let programs = (try? context.fetch(descriptor)) ?? []
+
+        guard let program = programs.first,
+              let template = ProgramTemplate.find(program.programTemplateID) else {
+            defaults?.removeObject(forKey: "widget.programProgress")
+            return
+        }
+
+        let grid = program.completionGrid
+        let totalDays = template.daysPerWeek * template.durationWeeks
+        let completedDays = grid.flatMap { $0 }.filter { $0 }.count
+
+        let data = ProgramProgressData(
+            programName: template.name,
+            currentWeek: program.currentWeek,
+            totalWeeks: template.durationWeeks,
+            completedDays: completedDays,
+            totalDays: totalDays,
+            percentage: totalDays > 0 ? Double(completedDays) / Double(totalDays) * 100 : 0,
+            updatedAt: .now
+        )
+        write(data, forKey: "widget.programProgress")
     }
 
     // MARK: - Private Helpers

--- a/CodeDump/Features/WorkoutSession/WorkoutSessionView.swift
+++ b/CodeDump/Features/WorkoutSession/WorkoutSessionView.swift
@@ -316,7 +316,7 @@ struct WorkoutSessionView: View {
 
         try? modelContext.save()
 
-        // Refresh widget data after session is saved
-        WidgetDataProvider.shared.refreshAll(context: modelContext)
+        // Refresh workout-relevant widgets (streak, heatmap, PR, program)
+        WidgetDataProvider.shared.refreshAfterWorkout(context: modelContext)
     }
 }

--- a/LDWELiveActivity/LDWEWidgetBundle.swift
+++ b/LDWELiveActivity/LDWEWidgetBundle.swift
@@ -12,5 +12,6 @@ struct LDWEWidgetBundle: WidgetBundle {
         WeeklyStreakWidget()
         MuscleHeatmapWidget()
         PRCelebrationWidget()
+        ProgramProgressWidget()
     }
 }

--- a/LDWELiveActivity/ProgramProgressWidget.swift
+++ b/LDWELiveActivity/ProgramProgressWidget.swift
@@ -1,0 +1,188 @@
+import SwiftUI
+import WidgetKit
+
+// MARK: - Timeline Provider
+
+struct ProgramProgressProvider: TimelineProvider {
+    func placeholder(in context: Context) -> ProgramProgressEntry {
+        ProgramProgressEntry(date: .now, data: .placeholder)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (ProgramProgressEntry) -> Void) {
+        let data = WidgetStore.read(ProgramProgressData.self, forKey: WidgetStore.programProgressKey)
+        completion(ProgramProgressEntry(date: .now, data: data))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<ProgramProgressEntry>) -> Void) {
+        let data = WidgetStore.read(ProgramProgressData.self, forKey: WidgetStore.programProgressKey)
+        let entry = ProgramProgressEntry(date: .now, data: data)
+
+        let nextUpdate = Calendar.current.date(byAdding: .hour, value: 1, to: .now)!
+        completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
+    }
+}
+
+// MARK: - Entry
+
+struct ProgramProgressEntry: TimelineEntry {
+    let date: Date
+    let data: ProgramProgressData?
+}
+
+// MARK: - Widget
+
+struct ProgramProgressWidget: Widget {
+    let kind = "ProgramProgressWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: ProgramProgressProvider()) { entry in
+            ProgramProgressWidgetView(entry: entry)
+                .containerBackground(for: .widget) {
+                    OutrunWidgetBackground()
+                }
+        }
+        .configurationDisplayName("Program Progress")
+        .description("Track your training program completion.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+// MARK: - Views
+
+struct ProgramProgressWidgetView: View {
+    let entry: ProgramProgressEntry
+
+    @Environment(\.widgetFamily) private var family
+
+    var body: some View {
+        if let data = entry.data {
+            switch family {
+            case .systemSmall:
+                smallView(data)
+            default:
+                mediumView(data)
+            }
+        } else {
+            noProgramView
+        }
+    }
+
+    // MARK: No Program
+
+    private var noProgramView: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "calendar.badge.plus")
+                .font(.system(size: 28))
+                .foregroundColor(.widgetCyan.opacity(0.5))
+
+            Text("NO PROGRAM")
+                .font(.widgetOutrun(11))
+                .foregroundColor(.white.opacity(0.4))
+
+            Text("Enroll to track progress")
+                .font(.system(size: 10))
+                .foregroundColor(.white.opacity(0.3))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: Small
+
+    private func smallView(_ data: ProgramProgressData) -> some View {
+        VStack(spacing: 8) {
+            progressRing(data: data, size: 72, lineWidth: 6)
+
+            Text("WEEK \(data.currentWeek)/\(data.totalWeeks)")
+                .font(.widgetOutrun(9))
+                .foregroundColor(.widgetCyan.opacity(0.7))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(2)
+    }
+
+    // MARK: Medium
+
+    private func mediumView(_ data: ProgramProgressData) -> some View {
+        HStack(spacing: 20) {
+            progressRing(data: data, size: 90, lineWidth: 7)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(data.programName.uppercased())
+                    .font(.widgetOutrun(12))
+                    .foregroundColor(.widgetYellow)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.6)
+
+                Text("WEEK \(data.currentWeek) OF \(data.totalWeeks)")
+                    .font(.widgetOutrun(10))
+                    .foregroundColor(.widgetCyan.opacity(0.7))
+
+                Text("\(data.completedDays)/\(data.totalDays) DAYS")
+                    .font(.widgetOutrun(10))
+                    .foregroundColor(.white.opacity(0.5))
+
+                Spacer()
+            }
+
+            Spacer()
+        }
+        .padding(2)
+    }
+
+    // MARK: Progress Ring
+
+    private func progressRing(data: ProgramProgressData, size: CGFloat, lineWidth: CGFloat) -> some View {
+        ZStack {
+            Circle()
+                .stroke(Color.widgetSurface, lineWidth: lineWidth)
+
+            Circle()
+                .trim(from: 0, to: data.progress)
+                .stroke(
+                    AngularGradient(
+                        colors: [progressColor(data).opacity(0.5), progressColor(data)],
+                        center: .center,
+                        startAngle: .degrees(0),
+                        endAngle: .degrees(360 * data.progress)
+                    ),
+                    style: StrokeStyle(lineWidth: lineWidth, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+                .neonGlow(progressColor(data), radius: 4)
+
+            VStack(spacing: 0) {
+                Text("\(Int(data.percentage))%")
+                    .font(.widgetOutrun(size * 0.22))
+                    .foregroundColor(progressColor(data))
+            }
+        }
+        .frame(width: size, height: size)
+    }
+
+    private func progressColor(_ data: ProgramProgressData) -> Color {
+        if data.progress >= 0.75 { return .widgetGreen }
+        if data.progress >= 0.5  { return .widgetCyan }
+        if data.progress >= 0.25 { return .widgetYellow }
+        return .widgetOrange
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Small", as: .systemSmall) {
+    ProgramProgressWidget()
+} timeline: {
+    ProgramProgressEntry(date: .now, data: .placeholder)
+}
+
+#Preview("Medium", as: .systemMedium) {
+    ProgramProgressWidget()
+} timeline: {
+    ProgramProgressEntry(date: .now, data: .placeholder)
+}
+
+#Preview("No Program", as: .systemSmall) {
+    ProgramProgressWidget()
+} timeline: {
+    ProgramProgressEntry(date: .now, data: nil)
+}

--- a/LDWELiveActivity/WidgetData.swift
+++ b/LDWELiveActivity/WidgetData.swift
@@ -13,10 +13,11 @@ enum WidgetStore {
 
     // MARK: - Keys
 
-    static let nextWorkoutKey   = "widget.nextWorkout"
-    static let weeklyStreakKey  = "widget.weeklyStreak"
-    static let muscleHeatmapKey = "widget.muscleHeatmap"
-    static let prCelebrationKey = "widget.prCelebration"
+    static let nextWorkoutKey      = "widget.nextWorkout"
+    static let weeklyStreakKey     = "widget.weeklyStreak"
+    static let muscleHeatmapKey   = "widget.muscleHeatmap"
+    static let prCelebrationKey   = "widget.prCelebration"
+    static let programProgressKey = "widget.programProgress"
 
     // MARK: - Read Helpers
 
@@ -118,5 +119,32 @@ struct PRCelebrationData: Codable {
         prType: .weight,
         displayValue: "185 lbs",
         achievedAt: .now
+    )
+}
+
+// MARK: - Program Progress Data
+
+struct ProgramProgressData: Codable {
+    let programName: String
+    let currentWeek: Int
+    let totalWeeks: Int
+    let completedDays: Int
+    let totalDays: Int
+    let percentage: Double
+    let updatedAt: Date
+
+    var progress: Double {
+        guard totalDays > 0 else { return 0 }
+        return min(1.0, Double(completedDays) / Double(totalDays))
+    }
+
+    static let placeholder = ProgramProgressData(
+        programName: "Push / Pull / Legs",
+        currentWeek: 3,
+        totalWeeks: 8,
+        completedDays: 12,
+        totalDays: 48,
+        percentage: 25,
+        updatedAt: .now
     )
 }


### PR DESCRIPTION
## Summary
- New **Program Progress** widget (small + medium) showing program name, current week, and completion percentage with progress ring
- Add `ProgramProgressData` struct mirrored between main app and widget extension
- Replace `reloadAllTimelines()` with targeted `reloadTimelines(ofKind:)` via new methods:
  - `refreshAfterWorkout()` — updates streak, heatmap, PR, and program widgets
  - `refreshAfterProgramChange()` — updates next workout and program progress widgets
- Workout completion now uses targeted refresh for efficiency

## Test plan
- [ ] Add Program Progress widget to home screen (small and medium sizes)
- [ ] Enroll in a program → widget shows program name, week 1, 0%
- [ ] Complete a program day → widget updates completion percentage
- [ ] No active program → widget shows "NO PROGRAM" empty state
- [ ] Complete a workout → streak/heatmap/PR widgets update (not all widgets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)