### PR TITLE
Add GPS tracking for runs and cycling workouts

### DIFF
--- a/CodeDump/Features/Strava/StravaManager.swift
+++ b/CodeDump/Features/Strava/StravaManager.swift
@@ -366,6 +366,7 @@ final class StravaManager: NSObject {
         case .strength: return "WeightTraining"
         case .hiit:     return "Workout"
         case .run:      return "Run"
+        case .cycling:  return "Ride"
         case .yoga:     return "Yoga"
         case .custom:   return "Workout"
         }
@@ -376,6 +377,7 @@ final class StravaManager: NSObject {
         case .strength: return "WeightTraining"
         case .hiit:     return "HIIT"
         case .run:      return "Run"
+        case .cycling:  return "Ride"
         case .yoga:     return "Yoga"
         case .custom:   return "Workout"
         }

--- a/CodeDump/Features/WorkoutCompleted/WorkoutCompletedView.swift
+++ b/CodeDump/Features/WorkoutCompleted/WorkoutCompletedView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import CoreLocation
 
 struct WorkoutCompletedView: View {
     let totalTime: Int
@@ -9,6 +10,8 @@ struct WorkoutCompletedView: View {
     var workout: Workout? = nil
     var allHistoricalLogs: [SetLog] = []
     var allSessions: [WorkoutSession] = []
+    var routeCoordinates: [CLLocationCoordinate2D] = []
+    var routeDistance: Double? = nil
     let onDone: () -> Void
 
     @State private var showingShare = false
@@ -28,6 +31,16 @@ struct WorkoutCompletedView: View {
                     // Improvement banner (PRs + volume delta)
                     if let summary, summary.prCount > 0 || summary.volumeDeltaPercent != nil {
                         improvementBanner(summary)
+                    }
+
+                    // Route map for GPS workouts
+                    if routeCoordinates.count >= 2 {
+                        RouteMapView(
+                            coordinates: routeCoordinates,
+                            distanceMeters: routeDistance,
+                            totalSeconds: totalTime,
+                            isCycling: workout?.workoutType == .cycling
+                        )
                     }
 
                     // Stats grid

--- a/CodeDump/Features/WorkoutSession/HealthKitManager.swift
+++ b/CodeDump/Features/WorkoutSession/HealthKitManager.swift
@@ -176,6 +176,7 @@ extension WorkoutType {
         switch self {
         case .hiit:     return .highIntensityIntervalTraining
         case .run:      return .running
+        case .cycling:  return .cycling
         case .yoga:     return .yoga
         case .strength: return .traditionalStrengthTraining
         case .custom:   return .functionalStrengthTraining
@@ -187,6 +188,7 @@ extension WorkoutType {
         switch self {
         case .hiit:     return 8.0
         case .run:      return 9.0
+        case .cycling:  return 7.5
         case .yoga:     return 3.0
         case .strength: return 5.0
         case .custom:   return 6.0

--- a/CodeDump/Features/WorkoutSession/LocationTracker.swift
+++ b/CodeDump/Features/WorkoutSession/LocationTracker.swift
@@ -1,0 +1,138 @@
+import CoreLocation
+import Foundation
+
+/// Tracks GPS location during run and cycling workouts.
+/// Collects a route of CLLocations and computes live distance/pace/speed.
+@MainActor
+@Observable
+final class LocationTracker: NSObject {
+    private(set) var locations: [CLLocation] = []
+    private(set) var isTracking = false
+
+    /// Total distance in meters
+    private(set) var distanceMeters: Double = 0
+
+    /// Current speed in m/s (from latest CLLocation, smoothed)
+    private(set) var currentSpeed: Double = 0
+
+    private let manager = CLLocationManager()
+    private var lastFilteredLocation: CLLocation?
+
+    override init() {
+        super.init()
+        manager.desiredAccuracy = kCLLocationAccuracyBest
+        manager.activityType = .fitness
+        manager.distanceFilter = 5 // meters — avoid jitter
+        #if os(iOS)
+        manager.allowsBackgroundLocationUpdates = true
+        manager.pausesLocationUpdatesAutomatically = false
+        manager.showsBackgroundLocationIndicator = true
+        #endif
+    }
+
+    // MARK: - Public
+
+    func requestPermission() {
+        manager.delegate = self
+        manager.requestWhenInUseAuthorization()
+    }
+
+    func start() {
+        locations = []
+        distanceMeters = 0
+        currentSpeed = 0
+        lastFilteredLocation = nil
+        isTracking = true
+        manager.delegate = self
+        manager.startUpdatingLocation()
+    }
+
+    func stop() {
+        isTracking = false
+        manager.stopUpdatingLocation()
+    }
+
+    // MARK: - Formatted Stats
+
+    /// Distance formatted as miles (e.g. "3.24 mi")
+    var formattedDistance: String {
+        let miles = distanceMeters / 1609.344
+        return String(format: "%.2f mi", miles)
+    }
+
+    /// Current pace as min/mile (e.g. "8:32 /mi") for running
+    var formattedPace: String {
+        guard currentSpeed > 0.3 else { return "-- /mi" }
+        let secondsPerMile = 1609.344 / currentSpeed
+        let minutes = Int(secondsPerMile) / 60
+        let seconds = Int(secondsPerMile) % 60
+        return String(format: "%d:%02d /mi", minutes, seconds)
+    }
+
+    /// Current speed in mph (e.g. "15.2 mph") for cycling
+    var formattedSpeed: String {
+        let mph = currentSpeed * 2.23694
+        return String(format: "%.1f mph", mph)
+    }
+
+    /// Average pace for the entire run
+    func averagePace(totalSeconds: Int) -> String {
+        let miles = distanceMeters / 1609.344
+        guard miles > 0.01 else { return "-- /mi" }
+        let secondsPerMile = Double(totalSeconds) / miles
+        let minutes = Int(secondsPerMile) / 60
+        let seconds = Int(secondsPerMile) % 60
+        return String(format: "%d:%02d /mi", minutes, seconds)
+    }
+
+    /// Average speed for the entire ride
+    func averageSpeed(totalSeconds: Int) -> String {
+        guard totalSeconds > 0 else { return "0.0 mph" }
+        let hours = Double(totalSeconds) / 3600
+        let miles = distanceMeters / 1609.344
+        return String(format: "%.1f mph", miles / hours)
+    }
+}
+
+// MARK: - CLLocationManagerDelegate
+
+extension LocationTracker: CLLocationManagerDelegate {
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didUpdateLocations newLocations: [CLLocation]) {
+        Task { @MainActor in
+            for location in newLocations {
+                // Filter out low-accuracy readings
+                guard location.horizontalAccuracy >= 0,
+                      location.horizontalAccuracy < 30 else { continue }
+
+                if let last = lastFilteredLocation {
+                    let delta = location.distance(from: last)
+                    // Ignore tiny movements (GPS jitter)
+                    guard delta >= 2 else { continue }
+                    distanceMeters += delta
+                }
+
+                lastFilteredLocation = location
+                locations.append(location)
+
+                // Smooth speed: use CLLocation's speed if positive, else compute
+                if location.speed >= 0 {
+                    currentSpeed = location.speed
+                } else if let last = locations.dropLast().last {
+                    let dt = location.timestamp.timeIntervalSince(last.timestamp)
+                    if dt > 0 {
+                        currentSpeed = location.distance(from: last) / dt
+                    }
+                }
+            }
+        }
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        // Location errors are non-fatal — just keep trying
+    }
+
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        // Re-check after user responds to permission prompt
+    }
+}

--- a/CodeDump/Features/WorkoutSession/RouteMapView.swift
+++ b/CodeDump/Features/WorkoutSession/RouteMapView.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+import MapKit
+
+/// Displays a GPS route on a map. Used in workout completion and history views.
+struct RouteMapView: View {
+    let coordinates: [CLLocationCoordinate2D]
+    let distanceMeters: Double?
+    let totalSeconds: Int
+    let isCycling: Bool
+
+    @State private var position: MapCameraPosition = .automatic
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Stats row
+            HStack(spacing: 16) {
+                routeStat(label: "DISTANCE", value: formattedDistance, color: .outrunCyan)
+                routeStat(label: isCycling ? "AVG SPEED" : "AVG PACE", value: formattedAvg, color: .outrunYellow)
+                routeStat(label: "DURATION", value: totalSeconds.formattedTimeLong, color: .outrunGreen)
+            }
+            .padding(.horizontal, 12)
+
+            // Map
+            Map(position: $position) {
+                if coordinates.count >= 2 {
+                    MapPolyline(coordinates: coordinates)
+                        .stroke(Color.outrunCyan, lineWidth: 4)
+                }
+
+                // Start marker
+                if let start = coordinates.first {
+                    Annotation("START", coordinate: start) {
+                        Circle()
+                            .fill(Color.outrunGreen)
+                            .frame(width: 12, height: 12)
+                            .overlay(Circle().stroke(.white, lineWidth: 2))
+                    }
+                }
+
+                // End marker
+                if let end = coordinates.last, coordinates.count > 1 {
+                    Annotation("FINISH", coordinate: end) {
+                        Circle()
+                            .fill(Color.outrunRed)
+                            .frame(width: 12, height: 12)
+                            .overlay(Circle().stroke(.white, lineWidth: 2))
+                    }
+                }
+            }
+            .mapStyle(.standard(pointsOfInterest: .excludingAll))
+            .frame(height: 220)
+            .cornerRadius(12)
+        }
+        .padding(12)
+        .background(Color.outrunSurface)
+        .cornerRadius(16)
+    }
+
+    private func routeStat(label: String, value: String, color: Color) -> some View {
+        VStack(spacing: 2) {
+            Text(label)
+                .font(.outrunFuture(9))
+                .foregroundColor(.white.opacity(0.4))
+            Text(value)
+                .font(.outrunFuture(14))
+                .foregroundColor(color)
+                .minimumScaleFactor(0.7)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var formattedDistance: String {
+        let miles = (distanceMeters ?? 0) / 1609.344
+        return String(format: "%.2f mi", miles)
+    }
+
+    private var formattedAvg: String {
+        let miles = (distanceMeters ?? 0) / 1609.344
+        if isCycling {
+            guard totalSeconds > 0 else { return "0.0 mph" }
+            let hours = Double(totalSeconds) / 3600
+            return String(format: "%.1f mph", miles / hours)
+        } else {
+            guard miles > 0.01 else { return "-- /mi" }
+            let secondsPerMile = Double(totalSeconds) / miles
+            let minutes = Int(secondsPerMile) / 60
+            let seconds = Int(secondsPerMile) % 60
+            return String(format: "%d:%02d /mi", minutes, seconds)
+        }
+    }
+}

--- a/CodeDump/Features/WorkoutSession/WorkoutSessionView.swift
+++ b/CodeDump/Features/WorkoutSession/WorkoutSessionView.swift
@@ -29,6 +29,8 @@ struct WorkoutSessionView: View {
                     workout: viewModel.workout,
                     allHistoricalLogs: allSetLogs,
                     allSessions: allSessions,
+                    routeCoordinates: viewModel.isGPSWorkout ? viewModel.locationTracker.locations.map(\.coordinate) : [],
+                    routeDistance: viewModel.isGPSWorkout ? viewModel.locationTracker.distanceMeters : nil,
                     onDone: { path.removeLast(path.count) }
                 )
             } else {
@@ -83,6 +85,12 @@ struct WorkoutSessionView: View {
             timerRing
 
             Spacer()
+
+            if viewModel.isGPSWorkout {
+                gpsStatsBar
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 8)
+            }
 
             exerciseInfo
                 .padding(.horizontal, 20)
@@ -213,6 +221,50 @@ struct WorkoutSessionView: View {
         }
     }
 
+    // MARK: - GPS Stats
+
+    private var gpsStatsBar: some View {
+        let tracker = viewModel.locationTracker
+        let isCycling = viewModel.workout.workoutType == .cycling
+        return HStack(spacing: 0) {
+            gpsStat(
+                label: "DISTANCE",
+                value: tracker.formattedDistance,
+                color: .outrunCyan
+            )
+            Spacer()
+            gpsStat(
+                label: isCycling ? "SPEED" : "PACE",
+                value: isCycling ? tracker.formattedSpeed : tracker.formattedPace,
+                color: .outrunYellow
+            )
+            Spacer()
+            gpsStat(
+                label: "AVG",
+                value: isCycling
+                    ? tracker.averageSpeed(totalSeconds: viewModel.totalElapsed)
+                    : tracker.averagePace(totalSeconds: viewModel.totalElapsed),
+                color: .outrunGreen
+            )
+        }
+        .padding(.vertical, 10)
+        .padding(.horizontal, 16)
+        .background(Color.outrunSurface)
+        .cornerRadius(12)
+    }
+
+    private func gpsStat(label: String, value: String, color: Color) -> some View {
+        VStack(spacing: 2) {
+            Text(label)
+                .font(.outrunFuture(9))
+                .foregroundColor(.white.opacity(0.4))
+            Text(value)
+                .font(.system(size: 16, weight: .semibold, design: .monospaced))
+                .foregroundColor(color)
+                .minimumScaleFactor(0.7)
+        }
+    }
+
     // MARK: - Exercise Info
 
     private var exerciseInfo: some View {
@@ -305,6 +357,12 @@ struct WorkoutSessionView: View {
         )
         session.workout = viewModel.workout
         viewModel.workout.sessions.append(session)
+
+        // Save GPS route data if applicable
+        if viewModel.isGPSWorkout, !viewModel.locationTracker.locations.isEmpty {
+            session.setRoute(from: viewModel.locationTracker.locations)
+        }
+
         modelContext.insert(session)
 
         // Persist set logs

--- a/CodeDump/Features/WorkoutSession/WorkoutSessionViewModel.swift
+++ b/CodeDump/Features/WorkoutSession/WorkoutSessionViewModel.swift
@@ -55,8 +55,15 @@ final class WorkoutSessionViewModel {
     private var timerTask: Task<Void, Never>?
     private let liveActivity = LiveActivityManager()
 
+    /// GPS tracker — active only for run/cycling workouts
+    let locationTracker = LocationTracker()
+    var isGPSWorkout: Bool { workout.workoutType.usesGPS }
+
     init(workout: Workout) {
         self.workout = workout
+        if workout.workoutType.usesGPS {
+            locationTracker.requestPermission()
+        }
     }
 
     // MARK: - Computed
@@ -139,6 +146,7 @@ final class WorkoutSessionViewModel {
     func startWorkout() {
         workoutStartDate = .now
         totalPausedTime = 0
+        if isGPSWorkout { locationTracker.start() }
         if workout.warmupLength > 0 {
             transition(to: .warmup)
         } else {
@@ -382,6 +390,7 @@ final class WorkoutSessionViewModel {
         if pendingLog != nil { commitSetLog() }
         isRunning = false
         timerTask?.cancel()
+        if isGPSWorkout { locationTracker.stop() }
         let start = workoutStartDate
         let end = start.addingTimeInterval(TimeInterval(totalElapsed))
         let type = workout.workoutType

--- a/CodeDump/Models/WorkoutModel.swift
+++ b/CodeDump/Models/WorkoutModel.swift
@@ -6,9 +6,14 @@ import Foundation
 enum WorkoutType: String, CaseIterable, Codable {
     case hiit     = "HIIT"
     case run      = "Run"
+    case cycling  = "Cycling"
     case yoga     = "Yoga"
     case strength = "Strength"
     case custom   = "Custom"
+
+    var usesGPS: Bool {
+        self == .run || self == .cycling
+    }
 }
 
 // MARK: - Workout

--- a/CodeDump/Models/WorkoutSession.swift
+++ b/CodeDump/Models/WorkoutSession.swift
@@ -1,5 +1,6 @@
 import SwiftData
 import Foundation
+import CoreLocation
 
 @Model
 final class WorkoutSession {
@@ -7,6 +8,11 @@ final class WorkoutSession {
     var totalElapsed: Int = 0      // seconds
     var exercisesCompleted: Int = 0
     var setsCompleted: Int = 0
+
+    /// GPS route data — JSON-encoded array of [lat, lon, timestamp, altitude]
+    var routeDataRaw: String?
+    /// Total distance in meters
+    var distanceMeters: Double?
 
     var workout: Workout?
 
@@ -18,5 +24,29 @@ final class WorkoutSession {
         self.totalElapsed = totalElapsed
         self.exercisesCompleted = exercisesCompleted
         self.setsCompleted = setsCompleted
+    }
+
+    // MARK: - Route Helpers
+
+    var routeCoordinates: [CLLocationCoordinate2D] {
+        guard let raw = routeDataRaw,
+              let data = raw.data(using: .utf8),
+              let points = try? JSONDecoder().decode([[Double]].self, from: data) else { return [] }
+        return points.compactMap { point in
+            guard point.count >= 2 else { return nil }
+            return CLLocationCoordinate2D(latitude: point[0], longitude: point[1])
+        }
+    }
+
+    func setRoute(from locations: [CLLocation]) {
+        let points = locations.map { [$0.coordinate.latitude, $0.coordinate.longitude, $0.timestamp.timeIntervalSince1970, $0.altitude] }
+        routeDataRaw = (try? String(data: JSONEncoder().encode(points), encoding: .utf8)) ?? nil
+
+        // Calculate total distance
+        var total: Double = 0
+        for i in 1..<locations.count {
+            total += locations[i].distance(from: locations[i - 1])
+        }
+        distanceMeters = total
     }
 }

--- a/CodeDump/Reference/Info.plist
+++ b/CodeDump/Reference/Info.plist
@@ -6,6 +6,19 @@
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
 	<string>Lazer Dragon</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>LDWE Workout</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.lazerdragon.workout</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -24,6 +37,20 @@
 	<string>public.app-category.healthcare-fitness</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>The Lazer Dragon tracks your route during runs and rides to map your path and calculate distance.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+	</array>
+	<key>NSHealthShareUsageDescription</key>
+	<string>"The Lazer Dragon sees all, but is politely asking for you to share your health data so that IT MAY RULE YOUR WORKOUTS."</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>"The Lazer Dragon politely requests that you let it write your workouts into Apple Health."</string>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
+	<key>NSUserNotificationsUsageDescription</key>
+	<string>The Lazer Dragon will remind you when it's time to train.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>OutrunFuture.otf</string>
@@ -38,14 +65,13 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
-	<key>NSUserNotificationsUsageDescription</key>
-	<string>The Lazer Dragon will remind you when it's time to train.</string>
-	<key>NSHealthShareUsageDescription</key>
-	<string>&quot;The Lazer Dragon sees all, but is politely asking for you to share your health data so that IT MAY RULE YOUR WORKOUTS.&quot;</string>
-	<key>NSHealthUpdateUsageDescription</key>
-	<string>&quot;The Lazer Dragon politely requests that you let it write your workouts into Apple Health.&quot;</string>
-	<key>NSSupportsLiveActivities</key>
-	<true/>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>
@@ -65,26 +91,6 @@
 				</array>
 			</dict>
 		</dict>
-	</array>
-	<key>CFBundleDocumentTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleTypeName</key>
-			<string>LDWE Workout</string>
-			<key>LSHandlerRank</key>
-			<string>Owner</string>
-			<key>LSItemContentTypes</key>
-			<array>
-				<string>com.lazerdragon.workout</string>
-			</array>
-		</dict>
-	</array>
-	<key>UISupportedInterfaceOrientations~ipad</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Add `cycling` workout type alongside existing `run` type
- New `LocationTracker` using CoreLocation with GPS jitter filtering, live distance/pace/speed, and background tracking
- Live GPS stats bar during session: distance, current pace (runs) or speed (cycling), and running average
- Route data saved to `WorkoutSession` as JSON-encoded coordinates + total distance
- `RouteMapView` displays route with start/finish markers on workout completion screen
- HealthKit + Strava mappings for cycling

## New files
- `LocationTracker.swift` — CoreLocation manager with accuracy filtering and live stats
- `RouteMapView.swift` — MapKit route display with stats overlay

## Modified files
- `WorkoutModel.swift` — added `cycling` type + `usesGPS` computed property
- `WorkoutSession.swift` — added `routeDataRaw`, `distanceMeters`, route helpers
- `WorkoutSessionViewModel.swift` — GPS start/stop lifecycle, `locationTracker` property
- `WorkoutSessionView.swift` — GPS stats bar, route data saved on completion
- `WorkoutCompletedView.swift` — route map shown for GPS workouts
- `HealthKitManager.swift` — cycling activity type + MET value
- `StravaManager.swift` — cycling → Ride mapping
- `Info.plist` — location permission + background mode

## Test plan
- [ ] Create a Run workout → start session → GPS stats bar shows distance/pace
- [ ] Create a Cycling workout → stats bar shows speed instead of pace
- [ ] Walk around briefly → distance increments, pace updates
- [ ] Complete workout → route map displays with start/finish markers
- [ ] Background the app during run → GPS continues tracking
- [ ] Non-GPS workout (strength) → no GPS bar, no location permission prompt
- [ ] Verify HealthKit saves cycling as `.cycling` activity type

🤖 Generated with [Claude Code](https://claude.com/claude-code)