### PR TITLE
Fix Gate 3 Nightly: install simulator runtime + wire up UI test instrumentation

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -s "$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1 || echo /Applications/Xcode.app)" && xcodebuild -version
 
+      - name: Install iOS Simulator
+        run: xcodebuild -downloadPlatform iOS
+
       - name: "Unit + Integration Tests (${{ matrix.device }})"
         run: |
           set -o pipefail
@@ -66,6 +69,9 @@ jobs:
 
       - name: Select Xcode
         run: sudo xcode-select -s "$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1 || echo /Applications/Xcode.app)" && xcodebuild -version
+
+      - name: Install iOS Simulator
+        run: xcodebuild -downloadPlatform iOS
 
       - name: Run E2E Tests
         env:

--- a/CodeDump/AppDelegate.swift
+++ b/CodeDump/AppDelegate.swift
@@ -63,6 +63,12 @@ struct RootView: View {
     @State private var selectedTab: Tab = .workouts
     @State private var workoutsPath = NavigationPath()
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
+    private var isUITesting: Bool {
+        ProcessInfo.processInfo.arguments.contains("-UITesting")
+    }
+    private var shouldShowOnboarding: Bool {
+        !hasCompletedOnboarding && !isUITesting
+    }
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \WorkoutSession.date, order: .reverse) private var recentSessions: [WorkoutSession]
     @State private var importedWorkout: WorkoutExport?
@@ -96,7 +102,7 @@ struct RootView: View {
                 .tag(Tab.goals)
         }
         .tint(.outrunCyan)
-        .fullScreenCover(isPresented: .constant(!hasCompletedOnboarding)) {
+        .fullScreenCover(isPresented: .constant(shouldShowOnboarding)) {
             OnboardingView {
                 hasCompletedOnboarding = true
             }

--- a/CodeDump/Features/Strava/StravaManager.swift
+++ b/CodeDump/Features/Strava/StravaManager.swift
@@ -114,7 +114,9 @@ final class StravaManager: NSObject {
 
     // MARK: - State
 
-    var isConnected: Bool { accessToken != nil }
+    private let uiTestingConnected: Bool?
+
+    var isConnected: Bool { uiTestingConnected ?? (accessToken != nil) }
     var isUploading = false
     var uploadResult: UploadResult?
 
@@ -129,6 +131,14 @@ final class StravaManager: NSObject {
          networkClient: StravaNetworkClient = URLSession.shared) {
         self.tokenStore = tokenStore
         self.networkClient = networkClient
+        let args = ProcessInfo.processInfo.arguments
+        if args.contains("-UITesting"),
+           let idx = args.firstIndex(of: "-StravaConnected"),
+           idx + 1 < args.count {
+            self.uiTestingConnected = args[idx + 1] == "YES"
+        } else {
+            self.uiTestingConnected = nil
+        }
     }
 
     // MARK: - Tokens (Store-backed)

--- a/CodeDump/Features/WorkoutSession/HealthKitManager.swift
+++ b/CodeDump/Features/WorkoutSession/HealthKitManager.swift
@@ -19,6 +19,8 @@ final class HealthKitManager {
 
     func requestAuthorization() async {
         guard isAvailable else { return }
+        // Skip the system permission sheet during UI tests — it blocks the workflow.
+        if ProcessInfo.processInfo.arguments.contains("-UITesting") { return }
         let share: Set<HKSampleType> = [
             HKObjectType.workoutType(),
             HKQuantityType(.activeEnergyBurned)

--- a/CodeDump/Features/WorkoutSession/WorkoutSessionView.swift
+++ b/CodeDump/Features/WorkoutSession/WorkoutSessionView.swift
@@ -335,6 +335,7 @@ struct WorkoutSessionView: View {
                 .overlay(Circle().stroke(color.opacity(0.3), lineWidth: 1))
         }
         .accessibilityLabel(icon == "backward.fill" ? "Previous exercise" : "Next exercise")
+        .accessibilityIdentifier(icon == "forward.fill" ? "skip_forward_button" : "skip_backward_button")
     }
 
     private var playPauseIcon: String {

--- a/CodeDump/Features/WorkoutSession/WorkoutSessionViewModel.swift
+++ b/CodeDump/Features/WorkoutSession/WorkoutSessionViewModel.swift
@@ -338,14 +338,16 @@ final class WorkoutSessionViewModel {
             exercisesCompleted += 1
 
             // Trigger set log prompt for the just-completed exercise
-            let exercise = sortedExercises[safe: i]
-            pendingLog = PendingSetLog(
-                exerciseName: exercise?.name ?? "Exercise",
-                exerciseTemplateID: exercise?.templateID,
-                setIndex: s,
-                exerciseIndex: i,
-                targetReps: exercise?.reps ?? 0
-            )
+            if !ProcessInfo.processInfo.arguments.contains("-UITesting") {
+                let exercise = sortedExercises[safe: i]
+                pendingLog = PendingSetLog(
+                    exerciseName: exercise?.name ?? "Exercise",
+                    exerciseTemplateID: exercise?.templateID,
+                    setIndex: s,
+                    exerciseIndex: i,
+                    targetReps: exercise?.reps ?? 0
+                )
+            }
 
             let isLastExercise = i + 1 >= exercisesPerSet
             let isLastSet = s + 1 >= workout.numberOfSets

--- a/CodeDumpUITests/StravaUITests.swift
+++ b/CodeDumpUITests/StravaUITests.swift
@@ -27,43 +27,50 @@ final class StravaUITests: XCTestCase {
     // MARK: - Helpers
 
     /// Navigate to the workout completed screen by starting and fast-forwarding a workout.
-    /// Requires seed data to exist (the app seeds in DEBUG builds).
+    /// Requires seed data to exist (the app seeds when the workout list is empty).
     private func navigateToCompletedScreen() {
         app.launch()
 
-        // Wait for the workout list to load
-        let workoutList = app.navigationBars["WORKOUTS"]
-        XCTAssertTrue(workoutList.waitForExistence(timeout: 5), "Workout list did not appear")
+        // Wait for the workout list to load (look for the seed "Easy Day" workout —
+        // the shortest seed workout for fast skip).
+        let easyWorkout = app.buttons.matching(NSPredicate(format: "label CONTAINS[c] 'Easy Day'")).firstMatch
+        XCTAssertTrue(easyWorkout.waitForExistence(timeout: 5), "Workout list did not appear")
+        easyWorkout.tap()
 
-        // Tap the first workout row to go to detail
-        let firstWorkout = app.cells.firstMatch
-        guard firstWorkout.waitForExistence(timeout: 3) else {
-            XCTFail("No workout rows found — seed data may not have loaded")
+        // Tap "BEGIN" to enter the workout session
+        let beginButton = app.buttons.matching(NSPredicate(format: "label CONTAINS[c] 'BEGIN'")).firstMatch
+        guard beginButton.waitForExistence(timeout: 3) else {
+            XCTFail("BEGIN button not found on detail screen")
             return
         }
-        firstWorkout.tap()
+        beginButton.tap()
 
-        // Tap "START" to begin the workout session
-        let startButton = app.buttons.matching(NSPredicate(format: "label CONTAINS[c] 'START'")).firstMatch
-        guard startButton.waitForExistence(timeout: 3) else {
-            XCTFail("START button not found on detail screen")
+        // Tap play to start the workout (session begins in idle)
+        let playButton = app.buttons.matching(NSPredicate(format: "label CONTAINS[c] 'Start workout'")).firstMatch
+        guard playButton.waitForExistence(timeout: 3) else {
+            XCTFail("Play button not found on session screen")
             return
         }
-        startButton.tap()
+        playButton.tap()
 
-        // Fast-forward: repeatedly tap the skip button until we reach completion
+        // Fast-forward: repeatedly tap skip forward until we reach completion.
+        // Set log overlays are suppressed in -UITesting mode (see WorkoutSessionViewModel).
+        // The SHARE button only exists on the completed screen, so use it as the sentinel —
+        // the COMPLETE Text has its accessibility merged into a combined parent label.
         let skipButton = app.buttons["skip_forward_button"]
-        let completedHeader = app.staticTexts["COMPLETE"]
+        let shareButton = app.buttons.matching(NSPredicate(format: "label CONTAINS[c] 'SHARE'")).firstMatch
 
         var taps = 0
-        while !completedHeader.exists && taps < 100 {
+        while !shareButton.exists && taps < 200 {
             if skipButton.exists && skipButton.isHittable {
                 skipButton.tap()
+            } else {
+                Thread.sleep(forTimeInterval: 0.2)
             }
             taps += 1
         }
 
-        XCTAssertTrue(completedHeader.waitForExistence(timeout: 5), "Did not reach completed screen after \(taps) skip taps")
+        XCTAssertTrue(shareButton.waitForExistence(timeout: 10), "Did not reach completed screen after \(taps) skip taps")
     }
 
     // MARK: - Disconnected State


### PR DESCRIPTION
## Summary

The nightly has been failing every night for ~2 weeks. Two bugs:

**1. iPhone 16 Pro Max destination unresolvable (exit 70)**

Xcode 16.4 on `macos-15` doesn't ship the iPhone 16 Pro Max simulator runtime. `tests.yml` already had `xcodebuild -downloadPlatform iOS` (commit `8bf027f`); `nightly.yml` was missed. Added it to both nightly jobs.

**2. StravaUITests broken on master (exit 65)**

These tests have never actually worked. The helper depended on app instrumentation that wasn't wired up:

- `-UITesting` launch arg now skips onboarding (`AppDelegate`), suppresses the set-log overlay during sessions (`WorkoutSessionViewModel`), and skips the HealthKit permission sheet (`HealthKitManager`). The HealthKit sheet was covering the skip button mid-test, which is why every run hit "Did not reach completed screen after N skip taps."
- `-StravaConnected YES|NO` flips `StravaManager.isConnected` without touching the keychain.
- `skip_forward_button` accessibility identifier added to the session control bar.
- Helper rewritten to navigate via the seed "Easy Day" workout (shortest seed) and waits on the SHARE button as the completion sentinel — `app.staticTexts["COMPLETE"]` never matched because the header VStack uses `.accessibilityElement(children: .ignore)`.

## Test plan

- [x] All 7 `StravaUITests` pass locally on iPhone 17 Pro
- [x] All 258 unit/integration tests still pass locally
- [ ] Trigger nightly via `workflow_dispatch` after merge to confirm it goes green on all 3 devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)