### PR TITLE
Fix CI: use iPhone 16 Pro and install simulator runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -s "$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1 || echo /Applications/Xcode.app)" && xcodebuild -version
 
+      - name: Install iOS Simulator
+        run: xcodebuild -downloadPlatform iOS
+
       - name: Unit + Integration + Contract + Concurrency + Accessibility + Error Injection
         run: |
           set -o pipefail
@@ -125,6 +128,9 @@ jobs:
 
       - name: Select Xcode
         run: sudo xcode-select -s "$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1 || echo /Applications/Xcode.app)" && xcodebuild -version
+
+      - name: Install iOS Simulator
+        run: xcodebuild -downloadPlatform iOS
 
       - name: UI Tests
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 env:
   SCHEME: CodeDump
   PROJECT: CodeDump.xcodeproj
-  DESTINATION: "platform=iOS Simulator,name=iPhone 17 Pro,OS=latest"
+  DESTINATION: "platform=iOS Simulator,name=iPhone 16 Pro,OS=latest"
   COVERAGE_THRESHOLD: 70
 
 jobs:
@@ -24,6 +24,9 @@ jobs:
 
       - name: Select Xcode
         run: sudo xcode-select -s "$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1 || echo /Applications/Xcode.app)" && xcodebuild -version
+
+      - name: Install iOS Simulator
+        run: xcodebuild -downloadPlatform iOS
 
       - name: Build & Test
         run: |
@@ -114,6 +117,9 @@ jobs:
 
       - name: Select Xcode
         run: sudo xcode-select -s "$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1 || echo /Applications/Xcode.app)" && xcodebuild -version
+
+      - name: Install iOS Simulator
+        run: xcodebuild -downloadPlatform iOS
 
       - name: Full Test Suite (including Keychain)
         run: |

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,7 +5,7 @@ default_platform(:ios)
 #───────────────────────────────────────────────────────────────────────
 SCHEME        = "CodeDump"
 PROJECT       = "CodeDump.xcodeproj"
-DEVICE        = "iPhone 17 Pro"
+DEVICE        = "iPhone 16 Pro"
 IOS_VERSION   = "latest"
 DESTINATION   = "platform=iOS Simulator,name=#{DEVICE},OS=#{IOS_VERSION}"
 COV_THRESHOLD = 70
@@ -71,7 +71,7 @@ platform :ios do
   #─────────────────────────────────────────────────────────────────────
   desc "Gate 3: Nightly — all tests + E2E against Strava sandbox + multi-device"
   lane :gate_nightly do
-    devices = ["iPhone 17e", "iPhone 17 Pro", "iPhone 17 Pro Max"]
+    devices = ["iPhone SE (3rd generation)", "iPhone 16 Pro", "iPhone 16 Pro Max"]
 
     # Fast tests on all device sizes
     scan(


### PR DESCRIPTION
## Summary
- Every recent **Tests & Coverage** run on master fails at `Build & Test` with `Unable to find a device matching the provided destination specifier { platform:iOS Simulator, OS:latest, name:iPhone 17 Pro }`. The macos-15 runners select Xcode 16.4 (the highest 16.x preinstalled), which can't host an iPhone 17 Pro simulator and ships with no iOS simulator runtime preinstalled at all.
- This PR matches the fix PR #22 already shipped for `nightly.yml`: switch the destination to `iPhone 16 Pro` and add an `xcodebuild -downloadPlatform iOS` step on every `xcodebuild test` job. Also realigns `fastlane/Fastfile` (single-device + Gate 3 multi-device list) so the Fastlane lanes don't drift back to iPhone 17.
- No app code changes.

## Test plan
- [ ] Gate 1 (`Tests & Coverage` on this PR) goes green
- [ ] After merge, manually trigger Gate 3 Nightly and confirm it goes green (PR #22 already added the runtime install + UI test instrumentation; this PR keeps fastlane in sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)