### PR TITLE
Pre-2.0 bug sweep: fix 7 open issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ iOSInjectionProject/
 
 # macOS
 .DS_Store
+
+# Claude Code workspace state
+.claude/

--- a/CodeDump/Features/Strava/StravaManager.swift
+++ b/CodeDump/Features/Strava/StravaManager.swift
@@ -1,6 +1,7 @@
 #if os(iOS)
 import Foundation
 import AuthenticationServices
+import Security
 
 // MARK: - Protocols for Testability
 
@@ -26,7 +27,8 @@ struct KeychainTokenStore: StravaTokenStore {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: key,
-            kSecAttrService as String: Self.service
+            kSecAttrService as String: Self.service,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
         ]
         SecItemDelete(query as CFDictionary)
         var addQuery = query
@@ -39,6 +41,7 @@ struct KeychainTokenStore: StravaTokenStore {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: key,
             kSecAttrService as String: Self.service,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne
         ]
@@ -120,6 +123,9 @@ final class StravaManager: NSObject {
     var isUploading = false
     var uploadResult: UploadResult?
 
+    /// CSRF nonce generated per `authorize()` and validated in the callback.
+    private var pendingAuthState: String?
+
     enum UploadResult: Equatable {
         case success
         case error(String)
@@ -196,13 +202,17 @@ final class StravaManager: NSObject {
     // MARK: - OAuth
 
     func authorize() {
+        let state = Self.makeAuthState()
+        pendingAuthState = state
+
         var components = URLComponents(string: Self.authorizeURL)!
         components.queryItems = [
             URLQueryItem(name: "client_id", value: Self.clientID),
             URLQueryItem(name: "redirect_uri", value: Self.redirectURI),
             URLQueryItem(name: "response_type", value: "code"),
             URLQueryItem(name: "approval_prompt", value: "auto"),
-            URLQueryItem(name: "scope", value: "activity:write,read")
+            URLQueryItem(name: "scope", value: "activity:write,read"),
+            URLQueryItem(name: "state", value: state)
         ]
 
         let session = ASWebAuthenticationSession(
@@ -211,6 +221,9 @@ final class StravaManager: NSObject {
         ) { [weak self] callbackURL, error in
             Task { @MainActor in
                 guard let self else { return }
+                let expectedState = self.pendingAuthState
+                self.pendingAuthState = nil
+
                 if let error {
                     if (error as NSError).code == ASWebAuthenticationSessionError.canceledLogin.rawValue {
                         return // User cancelled — not an error
@@ -219,8 +232,16 @@ final class StravaManager: NSObject {
                     return
                 }
                 guard let callbackURL,
-                      let code = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)?
-                        .queryItems?.first(where: { $0.name == "code" })?.value else {
+                      let queryItems = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)?.queryItems else {
+                    self.uploadResult = .error("No authorization code received.")
+                    return
+                }
+                let returnedState = queryItems.first(where: { $0.name == "state" })?.value
+                guard let expectedState, returnedState == expectedState else {
+                    self.uploadResult = .error("Authorization state mismatch.")
+                    return
+                }
+                guard let code = queryItems.first(where: { $0.name == "code" })?.value else {
                     self.uploadResult = .error("No authorization code received.")
                     return
                 }
@@ -230,6 +251,19 @@ final class StravaManager: NSObject {
         session.presentationContextProvider = self
         session.prefersEphemeralWebBrowserSession = false
         session.start()
+    }
+
+    private static func makeAuthState() -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        if status == errSecSuccess {
+            return Data(bytes).base64EncodedString()
+                .replacingOccurrences(of: "+", with: "-")
+                .replacingOccurrences(of: "/", with: "_")
+                .replacingOccurrences(of: "=", with: "")
+        }
+        // Fall back to UUID — still unguessable, lower entropy than 256 bits but acceptable.
+        return UUID().uuidString
     }
 
     func disconnect() {

--- a/CodeDump/Features/WorkoutSession/HealthKitManager.swift
+++ b/CodeDump/Features/WorkoutSession/HealthKitManager.swift
@@ -157,9 +157,13 @@ final class HealthKitManager {
             guard let firstDate = sortedLogs.first?.date,
                   let lastDate = sortedLogs.last?.date else { continue }
 
-            // Use log dates as segment boundaries, ensuring they fall within workout bounds
+            // Use log dates as segment boundaries, clamped to the workout window.
+            // SetLog timestamps frequently collapse (single log per exercise, or
+            // logs committed in rapid succession), so guarantee a non-zero span
+            // by extending the end at least 1s past the start when needed.
             let segStart = max(firstDate, workoutStart)
-            let segEnd = min(lastDate, workoutEnd)
+            let rawEnd = min(lastDate, workoutEnd)
+            let segEnd = max(rawEnd, min(segStart.addingTimeInterval(1), workoutEnd))
             guard segEnd > segStart else { continue }
 
             let dateInterval = DateInterval(start: segStart, end: segEnd)

--- a/CodeDump/Features/WorkoutSession/WorkoutSessionView.swift
+++ b/CodeDump/Features/WorkoutSession/WorkoutSessionView.swift
@@ -51,12 +51,15 @@ struct WorkoutSessionView: View {
             viewModel.historicalLogs = allSetLogs
         }
         .onChange(of: viewModel.phase) { _, newPhase in
+            // Auto-commit any pending log on every phase change. commitSetLog()
+            // is a no-op when pendingLog is nil, so this is safe to fire on
+            // .interval / .restBetweenSets / .completed alike. finishWorkout()
+            // also commits internally, so the .completed branch is defensive.
+            if viewModel.pendingLog != nil {
+                viewModel.commitSetLog()
+            }
             if case .completed = newPhase {
                 saveSession()
-            }
-            // Auto-commit any pending log when the next interval starts
-            if case .interval = newPhase, viewModel.pendingLog != nil {
-                viewModel.commitSetLog()
             }
         }
         .onChange(of: scenePhase) { _, newPhase in

--- a/CodeDump/Features/WorkoutSession/WorkoutSessionViewModel.swift
+++ b/CodeDump/Features/WorkoutSession/WorkoutSessionViewModel.swift
@@ -239,8 +239,11 @@ final class WorkoutSessionViewModel {
     }
 
     func endWorkout() {
+        // Route through finishWorkout so HealthKit save, Live Activity teardown,
+        // GPS stop, watch handler clear, and pendingLog auto-commit all run on
+        // the manual-end path instead of being skipped (issue #15).
         pause()
-        transition(to: .completed)
+        finishWorkout()
     }
 
     /// Called when the app returns to foreground. Restarts the tick loop so any
@@ -423,7 +426,10 @@ final class WorkoutSessionViewModel {
         timerTask?.cancel()
         if isGPSWorkout { locationTracker.stop() }
         let start = workoutStartDate
-        let end = start.addingTimeInterval(TimeInterval(totalElapsed))
+        // HealthKit rejects saves where endDate <= startDate. Guarantee at least
+        // a 1-second span so manual/instant-end workouts still persist.
+        let rawEnd = start.addingTimeInterval(TimeInterval(totalElapsed))
+        let end = max(rawEnd, start.addingTimeInterval(1))
         let type = workout.workoutType
         transition(to: .completed)
         liveActivity.end(finalState: currentActivityState)

--- a/CodeDump/Models/FitnessGoal.swift
+++ b/CodeDump/Models/FitnessGoal.swift
@@ -121,7 +121,17 @@ final class FitnessGoal {
 
     var exerciseName: String? {
         guard let tid = exerciseTemplateID else { return nil }
-        return ExerciseTemplate.library.first(where: { $0.id == tid })?.name
+        if let builtIn = ExerciseTemplate.library.first(where: { $0.id == tid })?.name {
+            return builtIn
+        }
+        // Goal references a CustomExerciseTemplate. Fetch by ID via the model
+        // context, which is non-nil once the goal has been inserted.
+        guard let context = modelContext else { return nil }
+        var descriptor = FetchDescriptor<CustomExerciseTemplate>(
+            predicate: #Predicate { $0.id == tid }
+        )
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first?.name
     }
 
     // MARK: - Auto-tracking


### PR DESCRIPTION
## Summary
Targeted fixes for the 7 open bugs blocking 2.0 release. Each fix is scoped to its issue with no incidental refactoring; combined diff is ~70 lines across 5 source files.

| Issue | Fix |
|---|---|
| #15 endWorkout bypasses finishWorkout | `endWorkout()` now calls `finishWorkout()` so HealthKit save, Live Activity teardown, GPS stop, watch handler clear, and pendingLog commit run on the manual-end path |
| #16 HealthKit endDate must be after startDate | `finishWorkout()` clamps end to `max(rawEnd, start+1s)` so instant-end workouts save |
| #17 Segments dropped when SetLogs share a timestamp | `buildSegmentEvents` extends `segEnd` to `start+1s` (clamped to workoutEnd) so single-log exercises produce a marker |
| #18 Custom-exercise goals display no name | `FitnessGoal.exerciseName` falls back to a `CustomExerciseTemplate` fetch via `modelContext` when the templateID isn't built-in |
| #19 Strava OAuth missing CSRF state | `authorize()` generates a 256-bit `SecRandomCopyBytes` nonce, sends as `state`, rejects callbacks whose returned state doesn't match |
| #20 Keychain missing kSecAttrAccessible | Save + read queries now set `kSecAttrAccessibleAfterFirstUnlock` for background reads after device unlock |
| #21 Pending log only auto-commits on .interval | View's `.onChange(phase)` commits the pending log on any phase change, no longer filters on `.interval` |

Also gitignores `.claude/` workspace state.

## Test plan
- [x] `xcodebuild build-for-testing` clean (verified locally on iPhone 17 Pro / iOS 26.3.1)
- [ ] Gate 1 (Tests & Coverage) green on this PR
- [ ] Manual: start workout → log a set → tap End → verify the log persists in `WorkoutCompleted` summary (issues #15 + #21)
- [ ] Manual: start workout, immediately tap End → verify it appears in Apple Health (issue #16)
- [ ] Manual: log only one set per exercise → verify Apple Health workout shows segment markers (issue #17)
- [ ] Manual: create a custom exercise, attach a `weightTarget` goal → verify the goal card shows the exercise name (issue #18)
- [ ] Manual: connect Strava → reboot device → verify connected state survives (issue #20)

Closes #15
Closes #16
Closes #17
Closes #18
Closes #19
Closes #20
Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)