### PR TITLE
Fix Gate 3 Nightly: StravaUITests isolation across cases

### DIFF
--- a/CodeDump/AppDelegate.swift
+++ b/CodeDump/AppDelegate.swift
@@ -9,6 +9,24 @@ struct LDWEApp: App {
         // Activate WatchConnectivity immediately so the session handshake
         // happens at launch, not only when a workout starts.
         _ = WatchConnectivityManager.shared
+
+        Self.resetTransientStateForUITestsIfNeeded()
+    }
+
+    /// Wipes accumulating session data (WorkoutSession, SetLog, FitnessGoal,
+    /// TrainingProgram, CustomExerciseTemplate) when the harness passes
+    /// `-ResetUITestData`. Tests that re-enter the workout flow each case
+    /// would otherwise see the workout list grow with prior runs' sessions,
+    /// shifting the layout enough to make seed-workout buttons not hittable.
+    private static func resetTransientStateForUITestsIfNeeded() {
+        guard ProcessInfo.processInfo.arguments.contains("-ResetUITestData") else { return }
+        let context = sharedContainer.mainContext
+        try? context.delete(model: WorkoutSession.self)
+        try? context.delete(model: SetLog.self)
+        try? context.delete(model: FitnessGoal.self)
+        try? context.delete(model: TrainingProgram.self)
+        try? context.delete(model: CustomExerciseTemplate.self)
+        try? context.save()
     }
 
     static let sharedContainer: ModelContainer = {

--- a/CodeDumpUITests/StravaUITests.swift
+++ b/CodeDumpUITests/StravaUITests.swift
@@ -16,39 +16,68 @@ final class StravaUITests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
-        // Pass launch arguments the app can read to configure test state
-        app.launchArguments += ["-UITesting", "YES"]
+        // -UITesting suppresses onboarding/HealthKit prompts and toggles the
+        //   set-log overlay off so the skip-forward loop reaches `.completed`.
+        // -ResetUITestData wipes any WorkoutSession/SetLog/etc. left over from
+        //   a prior test run so the workout list layout is deterministic —
+        //   without it, accumulating sessions push seed workouts down the
+        //   screen and "Easy Day" becomes not-hittable on smaller devices.
+        app.launchArguments += ["-UITesting", "YES", "-ResetUITestData"]
     }
 
     override func tearDownWithError() throws {
+        // Force-kill the app between tests. app.launch() should normally
+        // terminate any prior instance, but iOS 18 simulators sometimes leave
+        // the previous test's WorkoutCompleted screen layered over the
+        // workout list — the underlying button is in the accessibility tree
+        // but not hittable, which fails subsequent test setups with
+        // "Not hittable: Button ... 'Easy Day, Strength. ...'".
+        app?.terminate()
         app = nil
     }
 
     // MARK: - Helpers
+
+    /// Polls `isHittable` until it returns true or the timeout elapses. Use
+    /// this instead of bare `waitForExistence` when an element may exist in
+    /// the accessibility tree but be covered by an in-flight transition or
+    /// modal — common after a fresh `app.launch()` between cases.
+    private func waitUntilHittable(_ element: XCUIElement, timeout: TimeInterval = 5) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if element.exists && element.isHittable { return true }
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+        return false
+    }
 
     /// Navigate to the workout completed screen by starting and fast-forwarding a workout.
     /// Requires seed data to exist (the app seeds when the workout list is empty).
     private func navigateToCompletedScreen() {
         app.launch()
 
-        // Wait for the workout list to load (look for the seed "Easy Day" workout —
-        // the shortest seed workout for fast skip).
+        // Wait for the workout list to be the foreground view. The seed
+        // "Easy Day" workout is the shortest preset, so we use it to keep
+        // the skip-forward loop short.
         let easyWorkout = app.buttons.matching(NSPredicate(format: "label CONTAINS[c] 'Easy Day'")).firstMatch
-        XCTAssertTrue(easyWorkout.waitForExistence(timeout: 5), "Workout list did not appear")
+        guard waitUntilHittable(easyWorkout, timeout: 8) else {
+            XCTFail("Easy Day workout button not hittable — workout list may be covered by a stale modal")
+            return
+        }
         easyWorkout.tap()
 
         // Tap "BEGIN" to enter the workout session
         let beginButton = app.buttons.matching(NSPredicate(format: "label CONTAINS[c] 'BEGIN'")).firstMatch
-        guard beginButton.waitForExistence(timeout: 3) else {
-            XCTFail("BEGIN button not found on detail screen")
+        guard waitUntilHittable(beginButton, timeout: 3) else {
+            XCTFail("BEGIN button not hittable on detail screen")
             return
         }
         beginButton.tap()
 
         // Tap play to start the workout (session begins in idle)
         let playButton = app.buttons.matching(NSPredicate(format: "label CONTAINS[c] 'Start workout'")).firstMatch
-        guard playButton.waitForExistence(timeout: 3) else {
-            XCTFail("Play button not found on session screen")
+        guard waitUntilHittable(playButton, timeout: 3) else {
+            XCTFail("Play button not hittable on session screen")
             return
         }
         playButton.tap()
@@ -152,9 +181,12 @@ final class StravaUITests: XCTestCase {
         XCTAssertTrue(doneButton.waitForExistence(timeout: 3))
         doneButton.tap()
 
-        // Should return to the workout list
-        let workoutList = app.navigationBars["WORKOUTS"]
-        XCTAssertTrue(workoutList.waitForExistence(timeout: 5), "Should return to workout list after tapping Done")
+        // Should return to the workout list. The list's navbar uses a custom
+        // ToolbarItem (not .navigationTitle), so app.navigationBars["WORKOUTS"]
+        // doesn't match — assert on QUICK START instead, which only exists on
+        // the workout list and only when no modal/cover is on top of it.
+        let quickStart = app.buttons.matching(NSPredicate(format: "label CONTAINS[c] 'QUICK START'")).firstMatch
+        XCTAssertTrue(waitUntilHittable(quickStart, timeout: 5), "Should return to workout list after tapping Done")
     }
 
     // MARK: - Error State (visual check)


### PR DESCRIPTION
## Summary
The Gate 3 Nightly UI matrix has been failing on all 3 devices because of three independent test-isolation bugs in `StravaUITests`:

1. **Accumulating SwiftData state** — every case re-enters the workout flow and saves a `WorkoutSession`. By the 4th–5th test the workout list had enough recent activity underneath that the seed "Easy Day" row drifted off-screen / behind the QUICK START banner, and `XCUIElement.tap` reported `Not hittable`. The app now wipes `WorkoutSession` / `SetLog` / `FitnessGoal` / `TrainingProgram` / `CustomExerciseTemplate` at launch when `-ResetUITestData` is passed (no impact on production code paths).
2. **Stale modal between cases** — iOS 18 simulators occasionally leave the previous test's WorkoutCompleted screen layered over the relaunched app. `tearDown` now force-terminates explicitly, and the helper polls `isHittable` (not just `exists`) before tapping.
3. **Wrong selector in `testDoneButtonDismissesCompletedScreen`** — the test asserted on `app.navigationBars["WORKOUTS"]`, but `WorkoutListView` sets its title via a custom `ToolbarItem` (`outrunTitle`), so the navbar's identifier is empty. Replaced with a hittability check on the unique-to-list QUICK START button.

## Test plan
- [x] All 7 `StravaUITests` pass back-to-back locally on iPhone 17 Pro / iOS 26.3.1 (123s for the suite — verified)
- [x] No production-code changes outside the `-ResetUITestData` guarded reset path
- [ ] Gate 1 (`Tests & Coverage`) green on this PR
- [ ] After merge, manually trigger Gate 3 Nightly and confirm all 3 device matrix jobs go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)