### PR TITLE
CI: retry iOS simulator install on transient CDN failures

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,16 @@ jobs:
         run: sudo xcode-select -s "$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1 || echo /Applications/Xcode.app)" && xcodebuild -version
 
       - name: Install iOS Simulator
-        run: xcodebuild -downloadPlatform iOS
+        run: |
+          for i in 1 2 3; do
+            if xcodebuild -downloadPlatform iOS; then
+              exit 0
+            fi
+            echo "Attempt $i failed; retrying after $((i * 30))s..."
+            sleep $((i * 30))
+          done
+          echo "All 3 attempts to download iOS simulator failed."
+          exit 1
 
       - name: "Unit + Integration Tests (${{ matrix.device }})"
         run: |
@@ -71,7 +80,16 @@ jobs:
         run: sudo xcode-select -s "$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1 || echo /Applications/Xcode.app)" && xcodebuild -version
 
       - name: Install iOS Simulator
-        run: xcodebuild -downloadPlatform iOS
+        run: |
+          for i in 1 2 3; do
+            if xcodebuild -downloadPlatform iOS; then
+              exit 0
+            fi
+            echo "Attempt $i failed; retrying after $((i * 30))s..."
+            sleep $((i * 30))
+          done
+          echo "All 3 attempts to download iOS simulator failed."
+          exit 1
 
       - name: Run E2E Tests
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,16 @@ jobs:
         run: sudo xcode-select -s "$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1 || echo /Applications/Xcode.app)" && xcodebuild -version
 
       - name: Install iOS Simulator
-        run: xcodebuild -downloadPlatform iOS
+        run: |
+          for i in 1 2 3; do
+            if xcodebuild -downloadPlatform iOS; then
+              exit 0
+            fi
+            echo "Attempt $i failed; retrying after $((i * 30))s..."
+            sleep $((i * 30))
+          done
+          echo "All 3 attempts to download iOS simulator failed."
+          exit 1
 
       - name: Unit + Integration + Contract + Concurrency + Accessibility + Error Injection
         run: |
@@ -130,7 +139,16 @@ jobs:
         run: sudo xcode-select -s "$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1 || echo /Applications/Xcode.app)" && xcodebuild -version
 
       - name: Install iOS Simulator
-        run: xcodebuild -downloadPlatform iOS
+        run: |
+          for i in 1 2 3; do
+            if xcodebuild -downloadPlatform iOS; then
+              exit 0
+            fi
+            echo "Attempt $i failed; retrying after $((i * 30))s..."
+            sleep $((i * 30))
+          done
+          echo "All 3 attempts to download iOS simulator failed."
+          exit 1
 
       - name: UI Tests
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,19 @@ jobs:
         run: sudo xcode-select -s "$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1 || echo /Applications/Xcode.app)" && xcodebuild -version
 
       - name: Install iOS Simulator
-        run: xcodebuild -downloadPlatform iOS
+        run: |
+          # Apple's simulator-runtime CDN intermittently 5xx's during the
+          # initial connect, surfacing as `Unable to connect to simulator`
+          # then exit 70. Retry up to 3 times with backoff.
+          for i in 1 2 3; do
+            if xcodebuild -downloadPlatform iOS; then
+              exit 0
+            fi
+            echo "Attempt $i failed; retrying after $((i * 30))s..."
+            sleep $((i * 30))
+          done
+          echo "All 3 attempts to download iOS simulator failed."
+          exit 1
 
       - name: Build & Test
         run: |
@@ -119,7 +131,19 @@ jobs:
         run: sudo xcode-select -s "$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1 || echo /Applications/Xcode.app)" && xcodebuild -version
 
       - name: Install iOS Simulator
-        run: xcodebuild -downloadPlatform iOS
+        run: |
+          # Apple's simulator-runtime CDN intermittently 5xx's during the
+          # initial connect, surfacing as `Unable to connect to simulator`
+          # then exit 70. Retry up to 3 times with backoff.
+          for i in 1 2 3; do
+            if xcodebuild -downloadPlatform iOS; then
+              exit 0
+            fi
+            echo "Attempt $i failed; retrying after $((i * 30))s..."
+            sleep $((i * 30))
+          done
+          echo "All 3 attempts to download iOS simulator failed."
+          exit 1
 
       - name: Full Test Suite (including Keychain)
         run: |


### PR DESCRIPTION
## Summary
Apple's simulator-runtime CDN intermittently fails the initial connect from \`xcodebuild -downloadPlatform iOS\`, surfacing as \`Unable to connect to simulator. Finding content...\` then exit 70 in ~30 seconds. Until now that immediately fails the CI run and needs a manual \`gh run rerun\`. The same outage is currently red-flagging Gate 1 on PR #26 and was responsible for several earlier rerun cycles.

Wraps the install step in \`tests.yml\`, \`nightly.yml\`, and \`release.yml\` in a 3-try backoff loop (waits 30s, 60s; gives up after the third attempt) so transient hiccups don't take the gates down.

## Test plan
- [x] No app code changes
- [ ] Gate 1 green on this PR