### PR TITLE
StravaUITests: hybrid tap (prefer standard, coordinate fallback)

### DIFF
--- a/CodeDumpUITests/StravaUITests.swift
+++ b/CodeDumpUITests/StravaUITests.swift
@@ -36,15 +36,25 @@ final class StravaUITests: XCTestCase {
 
     // MARK: - Helpers
 
-    /// Taps at the element's center via a normalized coordinate, bypassing
-    /// the standard `isHittable` check. SwiftUI's List inserts transparent
-    /// overlays (swipe-actions hit zones, etc.) that intermittently make
-    /// rows and toolbar buttons report "Not hittable" even when they're
-    /// plainly visible. Coordinate taps still reach the underlying view
-    /// because they target the screen point directly.
+    /// Hybrid tap that works across iOS 18 and 26 simulators.
+    ///
+    /// - On iOS 18.5 (CI), `.tap()` works fine and `coord.tap()` on a list
+    ///   row with `.swipeActions` is sometimes interpreted as a swipe
+    ///   gesture (the row's button action never fires).
+    /// - On iOS 26 (local), `.tap()` aborts with "Not hittable" because
+    ///   SwiftUI inserts a transparent overlay over each row, even when
+    ///   the row is plainly visible. `coord.tap()` reaches the underlying
+    ///   button on iOS 26 because hit-testing happens at point level.
+    ///
+    /// Strategy: try `.tap()` first when the element reports hittable;
+    /// fall back to coordinate tap only when it doesn't.
     private func robustTap(_ element: XCUIElement) {
-        let coord = element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
-        coord.tap()
+        if element.exists && element.isHittable {
+            element.tap()
+        } else {
+            let coord = element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+            coord.tap()
+        }
     }
 
     /// Navigate to the workout completed screen by starting and fast-forwarding a workout.


### PR DESCRIPTION
## Summary
PR #26's coordinate-tap helper passed locally (iOS 26 / iPhone 17 Pro) but flipped two of the three device jobs in the post-merge nightly to a new failure: \`BEGIN button never appeared on detail screen\`. Root cause:

- **iOS 18.5 (CI):** \`XCUICoordinate.tap()\` on a SwiftUI list row that has \`.swipeActions\` is sometimes interpreted as a swipe gesture, so the row's Button action never fires and navigation doesn't happen.
- **iOS 26 (local):** bare \`element.tap()\` aborts with "Not hittable" because SwiftUI inserts a transparent overlay over each row.

Fix: hybrid helper that tries \`.tap()\` first when \`isHittable\` is true, falls back to coordinate tap only when it isn't. Correct path for both simulator generations.

## Test plan
- [ ] Gate 1 green on this PR
- [ ] Gate 3 Nightly multi-device matrix (iPhone SE / 16 Pro / 16 Pro Max) all green post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)