### PR TITLE
StravaUITests: deep-link past list + detail to bypass swipe-actions flake

### DIFF
--- a/CodeDump/AppDelegate.swift
+++ b/CodeDump/AppDelegate.swift
@@ -80,9 +80,11 @@ struct RootView: View {
     }
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \WorkoutSession.date, order: .reverse) private var recentSessions: [WorkoutSession]
+    @Query private var allWorkouts: [Workout]
     @State private var importedWorkout: WorkoutExport?
     @State private var showingImportAlert = false
     @State private var importError: String?
+    @State private var didAutoStartUITestSession = false
 
     var body: some View {
         TabView(selection: $selectedTab) {
@@ -121,6 +123,14 @@ struct RootView: View {
             styleTabBar()
             WidgetDataProvider.shared.refreshAll(context: modelContext)
             WatchConnectivityManager.shared.sendIdleContext(lastWorkoutDate: recentSessions.first?.date)
+            autoStartUITestSessionIfNeeded()
+        }
+        .onChange(of: allWorkouts) { _, _ in
+            // The seed runs in WorkoutListView.onAppear and populates this
+            // @Query asynchronously. Re-check once the seed lands so the
+            // UI-test deep-link fires even when the seed wasn't ready at
+            // RootView.onAppear.
+            autoStartUITestSessionIfNeeded()
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
             WidgetDataProvider.shared.refreshAll(context: modelContext)
@@ -174,6 +184,60 @@ struct RootView: View {
 
         UITabBar.appearance().standardAppearance = appearance
         UITabBar.appearance().scrollEdgeAppearance = appearance
+    }
+
+    // MARK: - UI-test deep link
+
+    /// When `-UITestStartSession` is set, push a minimal "Easy Day" workout
+    /// session onto the navigation path automatically. This skips the
+    /// workout-list and detail-screen taps, which are flaky on iOS 18.5
+    /// simulators because SwiftUI's List `.swipeActions` gesture
+    /// recognizer intercepts the cell tap. UI tests still navigate the
+    /// session itself (skip-forward → completed screen) — only the list
+    /// hop is bypassed.
+    private func autoStartUITestSessionIfNeeded() {
+        guard !didAutoStartUITestSession,
+              ProcessInfo.processInfo.arguments.contains("-UITestStartSession") else {
+            return
+        }
+        let easyDay: Workout
+        if let existing = allWorkouts.first(where: { $0.name == "Easy Day" }) {
+            easyDay = existing
+        } else {
+            // The in-memory store starts empty (see sharedContainer's
+            // -UITesting branch); insert a minimal Easy Day inline so we
+            // don't depend on WorkoutListView's onAppear-driven seed,
+            // which never runs when we deep-link past the list.
+            easyDay = Self.makeUITestSeedWorkout()
+            modelContext.insert(easyDay)
+            try? modelContext.save()
+        }
+        didAutoStartUITestSession = true
+        selectedTab = .workouts
+        workoutsPath.append(Route.session(easyDay))
+    }
+
+    private static func makeUITestSeedWorkout() -> Workout {
+        let workout = Workout(
+            name: "Easy Day",
+            type: .strength,
+            warmupLength: 5,
+            intervalLength: 5,
+            restLength: 5,
+            numberOfIntervals: 2,
+            numberOfSets: 1,
+            restBetweenSetLength: 5,
+            cooldownLength: 5
+        )
+        let exercises = [
+            Exercise(order: 0, name: "Push-ups", splitLength: 5, reps: 10, targetMuscleGroupsRaw: "chest", equipmentRaw: "bodyweight", templateID: "push-ups"),
+            Exercise(order: 1, name: "Squats", splitLength: 5, reps: 10, targetMuscleGroupsRaw: "quads", equipmentRaw: "bodyweight", templateID: "bodyweight-squats")
+        ]
+        for exercise in exercises {
+            exercise.workout = workout
+        }
+        workout.exercises = exercises
+        return workout
     }
 
     // MARK: - Import

--- a/CodeDumpUITests/StravaUITests.swift
+++ b/CodeDumpUITests/StravaUITests.swift
@@ -20,7 +20,11 @@ final class StravaUITests: XCTestCase {
         // set-log overlay off so the skip-forward loop reaches `.completed`,
         // and (in LDWEApp.sharedContainer) switches SwiftData to an
         // in-memory store so every launch starts with empty session state.
-        app.launchArguments += ["-UITesting", "YES"]
+        // -UITestStartSession deep-links straight into a synthetic Easy Day
+        // workout session, bypassing the workout list and detail screens
+        // (which were flaky on iOS 18.5 because of List swipe-actions
+        // intercepting cell taps).
+        app.launchArguments += ["-UITesting", "YES", "-UITestStartSession", "YES"]
     }
 
     override func tearDownWithError() throws {
@@ -57,38 +61,19 @@ final class StravaUITests: XCTestCase {
         }
     }
 
-    /// Navigate to the workout completed screen by starting and fast-forwarding a workout.
-    /// Requires seed data to exist (the app seeds when the workout list is empty).
+    /// Navigate to the workout completed screen by fast-forwarding the
+    /// auto-launched Easy Day session. The app deep-links straight into the
+    /// session view via `-UITestStartSession`, so the helper only has to
+    /// hit play and skip-forward to completion.
     private func navigateToCompletedScreen() {
         app.launch()
 
-        // Wait for the workout list to load, then tap the "Easy Day" row.
-        //
-        // We target the inner StaticText rather than the wrapping Button:
-        // SwiftUI's List rows have a `.swipeActions` modifier whose
-        // gesture recognizer swallows coordinate taps on the button area
-        // on iOS 18.5 simulators (the row's Button action never fires,
-        // so navigation doesn't happen). The StaticText sits outside that
-        // gesture zone but still propagates the tap up to the parent
-        // Button, so navigation goes through reliably on iOS 18 and 26.
-        let easyText = app.staticTexts.matching(NSPredicate(format: "label == 'Easy Day'")).firstMatch
-        guard easyText.waitForExistence(timeout: 10) else {
-            XCTFail("Easy Day workout text never appeared on workout list")
-            return
-        }
-        robustTap(easyText)
-
-        // Tap "BEGIN" to enter the workout session
-        let beginButton = app.buttons.matching(NSPredicate(format: "label CONTAINS[c] 'BEGIN'")).firstMatch
-        guard beginButton.waitForExistence(timeout: 5) else {
-            XCTFail("BEGIN button never appeared on detail screen")
-            return
-        }
-        robustTap(beginButton)
-
-        // Tap play to start the workout (session begins in idle)
+        // Tap play to start the workout (session begins in idle).
+        // 15s timeout because the deep-link insert+navigate occasionally
+        // takes a beat on iOS 26 simulators after a previous test left
+        // the app on the completed screen.
         let playButton = app.buttons.matching(NSPredicate(format: "label CONTAINS[c] 'Start workout'")).firstMatch
-        guard playButton.waitForExistence(timeout: 5) else {
+        guard playButton.waitForExistence(timeout: 15) else {
             XCTFail("Play button never appeared on session screen")
             return
         }


### PR DESCRIPTION
## Summary
PRs #25-29 chipped away at multi-device matrix flakiness, but the same root cause kept resurfacing: SwiftUI's \`.swipeActions\` gesture recognizer on List rows intermittently swallows taps, so the row Button never fires its action. Hybrid taps and StaticText targets helped some devices but not others.

This PR stops fighting the list/detail navigation entirely. When \`-UITestStartSession\` is set:
- \`LDWEApp.sharedContainer\` was already in-memory for \`-UITesting\`
- \`RootView\` now inserts a minimal Easy Day workout (2 exercises × 5s intervals) and deep-links straight to its session view
- The test helper drops the list-tap → detail-tap → BEGIN-tap chain; it only waits for the Play button + skip-forwards to completion

The minimal workout structure cuts the skip-forward loop from ~22 taps to ~10, which also halves suite runtime (~150s → ~75s).

Production code paths are untouched — none of this fires without the launch arg.

## Test plan
- [x] 2 consecutive local runs on iPhone 17 Pro / iOS 26.3.1: all 7 tests pass each time
- [ ] Gate 1 green on this PR
- [ ] Gate 3 Nightly: all 3 device matrix jobs (iPhone SE / 16 Pro / 16 Pro Max) green post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)