### PR TITLE
Add Strength Score: single trending fitness number

### DIFF
--- a/CodeDump/Features/Body/BodyStatusView.swift
+++ b/CodeDump/Features/Body/BodyStatusView.swift
@@ -9,6 +9,8 @@ struct BodyStatusView: View {
     @State private var muscleCards: [MuscleCardData] = []
     @State private var recommendedMuscles: [MuscleGroup] = []
     @State private var weeklyStats: (sessions: Int, sets: Int, volume: Double) = (0, 0, 0)
+    @State private var strengthScore: StrengthScoreEngine.StrengthScore?
+    @State private var strengthTrend: [StrengthScoreEngine.TrendPoint] = []
     #if os(iOS)
     @State private var recoveryScore: RecoveryScore?
     #endif
@@ -24,6 +26,7 @@ struct BodyStatusView: View {
 
             ScrollView {
                 VStack(spacing: 16) {
+                    strengthScoreSection
                     #if os(iOS)
                     recoveryBar
                     #endif
@@ -90,6 +93,12 @@ struct BodyStatusView: View {
             .filter { $0 != .fullBody }
 
         computeWeeklyStats()
+        computeStrengthScore()
+    }
+
+    private func computeStrengthScore() {
+        strengthScore = StrengthScoreEngine.score(sessions: sessions, setLogs: setLogs)
+        strengthTrend = StrengthScoreEngine.trend(sessions: sessions, setLogs: setLogs)
     }
 
     private func computeWeeklyStats() {
@@ -187,6 +196,15 @@ struct BodyStatusView: View {
         return .outrunOrange
     }
     #endif
+
+    // MARK: - Strength Score
+
+    @ViewBuilder
+    private var strengthScoreSection: some View {
+        if let score = strengthScore {
+            StrengthScoreCard(score: score, trend: strengthTrend)
+        }
+    }
 
     // MARK: - Weekly Stats
 

--- a/CodeDump/Features/Body/StrengthScoreCard.swift
+++ b/CodeDump/Features/Body/StrengthScoreCard.swift
@@ -1,0 +1,191 @@
+import SwiftUI
+import Charts
+
+/// Single trending fitness number with a 12-week sparkline and component
+/// breakdown. Sits at the top of the Body tab, above the recovery bar.
+///
+/// The card is purely presentational — score + trend are computed in
+/// `StrengthScoreEngine` and passed in.
+struct StrengthScoreCard: View {
+    let score: StrengthScoreEngine.StrengthScore
+    let trend: [StrengthScoreEngine.TrendPoint]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            header
+            scoreLine
+            sparkline
+            breakdown
+        }
+        .padding(16)
+        .background(Color.outrunSurface)
+        .cornerRadius(12)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color.outrunCyan.opacity(0.25), lineWidth: 1)
+        )
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            Text("STRENGTH SCORE")
+                .font(.outrunFuture(11))
+                .foregroundColor(.outrunCyan.opacity(0.8))
+            Spacer()
+            if let delta = score.trend.deltaText {
+                Text(delta)
+                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                    .foregroundColor(deltaColor)
+            }
+        }
+    }
+
+    private var deltaColor: Color {
+        switch score.trend {
+        case .up:      return .outrunGreen
+        case .down:    return .outrunRed
+        case .flat:    return .white.opacity(0.5)
+        case .unknown: return .white.opacity(0.4)
+        }
+    }
+
+    // MARK: - Score line
+
+    private var scoreLine: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(scoreText)
+                .font(.system(size: 44, weight: .bold, design: .monospaced))
+                .foregroundColor(.outrunCyan)
+                .minimumScaleFactor(0.5)
+                .lineLimit(1)
+
+            if !score.hasData {
+                Text("LOG A SET TO START")
+                    .font(.outrunFuture(10))
+                    .foregroundColor(.white.opacity(0.5))
+            } else {
+                Text("PTS")
+                    .font(.outrunFuture(11))
+                    .foregroundColor(.white.opacity(0.4))
+                    .padding(.bottom, 6)
+            }
+        }
+    }
+
+    private var scoreText: String {
+        score.total.formatted(.number.grouping(.automatic))
+    }
+
+    // MARK: - Sparkline
+
+    @ViewBuilder
+    private var sparkline: some View {
+        if hasTrendData {
+            Chart(trend) { point in
+                LineMark(
+                    x: .value("Week", point.date),
+                    y: .value("Score", point.score)
+                )
+                .foregroundStyle(Color.outrunCyan)
+                .interpolationMethod(.catmullRom)
+                .lineStyle(StrokeStyle(lineWidth: 2))
+
+                AreaMark(
+                    x: .value("Week", point.date),
+                    y: .value("Score", point.score)
+                )
+                .foregroundStyle(
+                    LinearGradient(
+                        colors: [.outrunCyan.opacity(0.35), .outrunCyan.opacity(0)],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+                .interpolationMethod(.catmullRom)
+            }
+            .chartXAxis(.hidden)
+            .chartYAxis(.hidden)
+            .frame(height: 56)
+        } else {
+            Rectangle()
+                .fill(Color.outrunBlack.opacity(0.4))
+                .frame(height: 56)
+                .overlay(
+                    Text("BUILDING TREND…")
+                        .font(.outrunFuture(9))
+                        .foregroundColor(.white.opacity(0.3))
+                )
+                .cornerRadius(8)
+        }
+    }
+
+    private var hasTrendData: Bool {
+        // Need at least 2 non-zero points to draw a meaningful line.
+        trend.filter { $0.score > 0 }.count >= 2
+    }
+
+    // MARK: - Component breakdown
+
+    private var breakdown: some View {
+        HStack(spacing: 12) {
+            componentChip(
+                label: "STRENGTH",
+                value: Int(score.strengthComponent.rounded()).formatted(.number.grouping(.automatic)),
+                color: .outrunYellow,
+                icon: "bolt.fill"
+            )
+            componentChip(
+                label: "VOLUME",
+                value: Int(score.volumeComponent.rounded()).formatted(.number.grouping(.automatic)),
+                color: .outrunPink,
+                icon: "scalemass.fill"
+            )
+            componentChip(
+                label: "FREQUENCY",
+                value: "\(score.frequencyComponent)",
+                color: .outrunGreen,
+                icon: "calendar"
+            )
+        }
+    }
+
+    private func componentChip(label: String, value: String, color: Color, icon: String) -> some View {
+        VStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 10))
+                .foregroundColor(color.opacity(0.7))
+            Text(value)
+                .font(.system(size: 13, weight: .bold, design: .monospaced))
+                .foregroundColor(color)
+                .minimumScaleFactor(0.6)
+                .lineLimit(1)
+            Text(label)
+                .font(.outrunFuture(7))
+                .foregroundColor(.white.opacity(0.5))
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 8)
+        .background(Color.outrunBlack.opacity(0.5))
+        .cornerRadius(8)
+    }
+
+    // MARK: - Accessibility
+
+    private var accessibilityLabel: String {
+        var parts: [String] = ["Strength score: \(score.total) points."]
+        switch score.trend {
+        case .up(let d):   parts.append("Up \(d) versus last 28 days.")
+        case .down(let d): parts.append("Down \(d) versus last 28 days.")
+        case .flat:        parts.append("Unchanged versus last 28 days.")
+        case .unknown:     break
+        }
+        parts.append("Strength component \(Int(score.strengthComponent.rounded())).")
+        parts.append("Volume component \(Int(score.volumeComponent.rounded())).")
+        parts.append("Frequency \(score.frequencyComponent) sessions.")
+        return parts.joined(separator: " ")
+    }
+}

--- a/CodeDump/Models/StrengthScoreEngine.swift
+++ b/CodeDump/Models/StrengthScoreEngine.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+// MARK: - Strength Score Engine
+
+/// Pure-logic engine that computes a single trending fitness number from
+/// existing workout history. Mirrors the shape of MuscleAnalyzer and
+/// RecoveryAnalyzer — Foundation-only, no UI, deterministic output for a
+/// given input.
+///
+/// The score blends three components evaluated over a trailing window:
+/// - **Strength**: sum of the user's best estimated-1RM (Epley) per unique
+///   exercise template they trained.
+/// - **Volume**: total weight × reps performed.
+/// - **Frequency**: number of distinct workout sessions completed.
+///
+/// The total is `strength + volume/50 + frequency*100`, which lands a
+/// regularly training intermediate lifter in the ~2,000-5,000 range and
+/// keeps the components on similar order of magnitude. The score is
+/// intentionally not normalized to 0-100 — it's meant to grow as the user
+/// grows, the way Fitbod's Fitness Level does.
+struct StrengthScoreEngine {
+
+    static let windowDays = 28
+
+    // MARK: - Public types
+
+    struct StrengthScore: Equatable {
+        let total: Int
+        let strengthComponent: Double
+        let volumeComponent: Double
+        let frequencyComponent: Int
+        let computedAt: Date
+        let trend: ScoreTrend
+
+        var hasData: Bool { strengthComponent > 0 || volumeComponent > 0 || frequencyComponent > 0 }
+    }
+
+    enum ScoreTrend: Equatable {
+        case up(delta: Int)
+        case down(delta: Int)
+        case flat
+        case unknown
+
+        var deltaText: String? {
+            switch self {
+            case .up(let d):   return "▲ +\(d)"
+            case .down(let d): return "▼ -\(d)"
+            case .flat:        return "→ 0"
+            case .unknown:     return nil
+            }
+        }
+    }
+
+    struct TrendPoint: Identifiable, Equatable {
+        let date: Date
+        let score: Int
+        var id: Date { date }
+    }
+
+    // MARK: - Score (current)
+
+    /// Computes the strength score over the trailing `windowDays` ending at
+    /// `asOf`, plus a delta versus the prior equally-sized window.
+    static func score(
+        sessions: [WorkoutSession],
+        setLogs: [SetLog],
+        asOf: Date = .now
+    ) -> StrengthScore {
+        let current = rawScore(sessions: sessions, setLogs: setLogs, endingAt: asOf)
+        let previous = rawScore(
+            sessions: sessions,
+            setLogs: setLogs,
+            endingAt: Calendar.current.date(byAdding: .day, value: -windowDays, to: asOf) ?? asOf
+        )
+
+        let trend: ScoreTrend
+        if previous.total == 0 && current.total == 0 {
+            trend = .unknown
+        } else if previous.total == 0 {
+            trend = .up(delta: current.total)
+        } else {
+            let delta = current.total - previous.total
+            switch delta {
+            case 0:                      trend = .flat
+            case ..<0:                   trend = .down(delta: -delta)
+            default:                     trend = .up(delta: delta)
+            }
+        }
+
+        return StrengthScore(
+            total: current.total,
+            strengthComponent: current.strength,
+            volumeComponent: current.volume,
+            frequencyComponent: current.frequency,
+            computedAt: asOf,
+            trend: trend
+        )
+    }
+
+    // MARK: - Trend (historical)
+
+    /// Returns one TrendPoint per week for the last `weeks` weeks, oldest
+    /// first. Each point's score reflects the trailing-window calculation
+    /// as of that week's end, so the curve is smooth rather than jagged.
+    static func trend(
+        sessions: [WorkoutSession],
+        setLogs: [SetLog],
+        asOf: Date = .now,
+        weeks: Int = 12
+    ) -> [TrendPoint] {
+        guard weeks > 0 else { return [] }
+        let calendar = Calendar.current
+        var points: [TrendPoint] = []
+
+        for offset in stride(from: weeks - 1, through: 0, by: -1) {
+            guard let endDate = calendar.date(byAdding: .day, value: -offset * 7, to: asOf) else { continue }
+            let raw = rawScore(sessions: sessions, setLogs: setLogs, endingAt: endDate)
+            points.append(TrendPoint(date: endDate, score: raw.total))
+        }
+
+        return points
+    }
+
+    // MARK: - Internals
+
+    private struct Raw {
+        let total: Int
+        let strength: Double
+        let volume: Double
+        let frequency: Int
+    }
+
+    private static func rawScore(
+        sessions: [WorkoutSession],
+        setLogs: [SetLog],
+        endingAt: Date
+    ) -> Raw {
+        guard let windowStart = Calendar.current.date(byAdding: .day, value: -windowDays, to: endingAt) else {
+            return Raw(total: 0, strength: 0, volume: 0, frequency: 0)
+        }
+
+        let frequency = sessions.filter { $0.date > windowStart && $0.date <= endingAt }.count
+
+        let logsInWindow = setLogs.filter { $0.date > windowStart && $0.date <= endingAt && ($0.weight ?? 0) > 0 }
+
+        var volume: Double = 0
+        var bestE1RMByKey: [String: Double] = [:]
+
+        for log in logsInWindow {
+            let w = log.weight ?? 0
+            let r = log.reps ?? 0
+            volume += w * Double(r)
+
+            let key = log.exerciseTemplateID ?? log.exerciseName
+            guard !key.isEmpty else { continue }
+            // Epley formula, identical to ExerciseProgressChartView's metric.
+            let e1RM = r > 0 ? w * (1 + Double(r) / 30.0) : w
+            if e1RM > (bestE1RMByKey[key] ?? 0) {
+                bestE1RMByKey[key] = e1RM
+            }
+        }
+
+        let strength = bestE1RMByKey.values.reduce(0, +)
+        let total = Int(strength.rounded()) + Int((volume / 50).rounded()) + (frequency * 100)
+
+        return Raw(total: total, strength: strength, volume: volume, frequency: frequency)
+    }
+}

--- a/CodeDumpTests/StrengthScoreEngineTests.swift
+++ b/CodeDumpTests/StrengthScoreEngineTests.swift
@@ -1,0 +1,229 @@
+import XCTest
+import SwiftData
+@testable import Lazer_Dragon
+
+@MainActor
+final class StrengthScoreEngineTests: XCTestCase {
+
+    // MARK: - Setup
+
+    private var anchorDate: Date!
+
+    override func setUp() async throws {
+        // Pin "now" to a fixed date so trend windows are deterministic
+        // regardless of when the suite runs.
+        anchorDate = Date(timeIntervalSince1970: 1_720_000_000)
+    }
+
+    // MARK: - Empty state
+
+    func testEmptyHistoryReturnsZeroScoreAndUnknownTrend() {
+        let score = StrengthScoreEngine.score(sessions: [], setLogs: [], asOf: anchorDate)
+        XCTAssertEqual(score.total, 0)
+        XCTAssertEqual(score.strengthComponent, 0)
+        XCTAssertEqual(score.volumeComponent, 0)
+        XCTAssertEqual(score.frequencyComponent, 0)
+        XCTAssertFalse(score.hasData)
+        XCTAssertEqual(score.trend, .unknown)
+    }
+
+    // MARK: - Components
+
+    func testFrequencyCountsSessionsInWindow() {
+        let inWindow = [
+            session(daysAgo: 1),
+            session(daysAgo: 7),
+            session(daysAgo: 27)
+        ]
+        let outside = [session(daysAgo: 40), session(daysAgo: 60)]
+        let score = StrengthScoreEngine.score(
+            sessions: inWindow + outside,
+            setLogs: [],
+            asOf: anchorDate
+        )
+        XCTAssertEqual(score.frequencyComponent, 3)
+        XCTAssertEqual(score.total, 300, "frequency * 100 should land 3 sessions at 300")
+    }
+
+    func testVolumeSumsWeightTimesRepsForSetsInWindow() {
+        let logs = [
+            log(daysAgo: 2, weight: 100, reps: 10), // 1000
+            log(daysAgo: 5, weight: 50, reps: 20),  // 1000
+            log(daysAgo: 40, weight: 200, reps: 10) // outside window
+        ]
+        let score = StrengthScoreEngine.score(sessions: [], setLogs: logs, asOf: anchorDate)
+        XCTAssertEqual(score.volumeComponent, 2_000, accuracy: 0.001)
+    }
+
+    func testStrengthSumsBest1RMPerExercise() {
+        // Two exercises, multiple logs each — strength = sum of best 1RM each
+        // bench: max e1RM is 100 * (1 + 5/30) = 116.66...
+        // squat: max e1RM is 200 * (1 + 5/30) = 233.33...
+        let logs = [
+            log(daysAgo: 1, weight: 80, reps: 10, templateID: "bench"),  // 80*(1+10/30) = 106.66
+            log(daysAgo: 2, weight: 100, reps: 5, templateID: "bench"),  // 100*(1+5/30) = 116.66
+            log(daysAgo: 3, weight: 180, reps: 8, templateID: "squat"),  // 180*(1+8/30) = 228
+            log(daysAgo: 4, weight: 200, reps: 5, templateID: "squat")   // 200*(1+5/30) = 233.33
+        ]
+        let score = StrengthScoreEngine.score(sessions: [], setLogs: logs, asOf: anchorDate)
+        XCTAssertEqual(score.strengthComponent, 116.666_67 + 233.333_33, accuracy: 0.01)
+    }
+
+    func testStrengthFallsBackToExerciseNameWhenTemplateIDMissing() {
+        let logs = [
+            log(daysAgo: 1, weight: 100, reps: 1, templateID: nil, name: "Push Press")
+        ]
+        let score = StrengthScoreEngine.score(sessions: [], setLogs: logs, asOf: anchorDate)
+        // Epley at 100 lbs × 1 rep = 100 * (1 + 1/30) = 103.333…
+        XCTAssertEqual(score.strengthComponent, 103.333, accuracy: 0.01)
+    }
+
+    func testZeroRepsTreatedAsRawWeight() {
+        // duration-based exercises log without reps; e1RM should equal weight
+        let logs = [log(daysAgo: 1, weight: 50, reps: 0, templateID: "plank")]
+        let score = StrengthScoreEngine.score(sessions: [], setLogs: logs, asOf: anchorDate)
+        XCTAssertEqual(score.strengthComponent, 50, accuracy: 0.01)
+    }
+
+    func testWeightlessLogsExcludedFromStrengthAndVolume() {
+        let logs = [
+            log(daysAgo: 1, weight: nil, reps: 10),
+            log(daysAgo: 2, weight: 0, reps: 10)
+        ]
+        let score = StrengthScoreEngine.score(sessions: [], setLogs: logs, asOf: anchorDate)
+        XCTAssertEqual(score.strengthComponent, 0)
+        XCTAssertEqual(score.volumeComponent, 0)
+    }
+
+    // MARK: - Total formula
+
+    func testTotalIsStrengthPlusScaledVolumePlusFrequency() {
+        let sessions = [session(daysAgo: 1), session(daysAgo: 5)]
+        let logs = [
+            log(daysAgo: 1, weight: 100, reps: 10, templateID: "bench"),
+            log(daysAgo: 5, weight: 100, reps: 5, templateID: "bench")
+        ]
+        let score = StrengthScoreEngine.score(sessions: sessions, setLogs: logs, asOf: anchorDate)
+        // Best e1RM for bench: max(133.33, 116.66) = 133.33
+        // Volume: 1000 + 500 = 1500. /50 = 30
+        // Frequency: 2 * 100 = 200
+        // Total: 133 (rounded) + 30 + 200 = 363
+        XCTAssertEqual(score.total, 363)
+    }
+
+    // MARK: - Trend / delta
+
+    func testTrendIsUpWhenCurrentExceedsPrevious() {
+        // Previous 28-day window had 2 sessions; current window has 4.
+        let sessions = [
+            session(daysAgo: 5),
+            session(daysAgo: 10),
+            session(daysAgo: 15),
+            session(daysAgo: 20),
+            session(daysAgo: 35),
+            session(daysAgo: 40)
+        ]
+        let score = StrengthScoreEngine.score(sessions: sessions, setLogs: [], asOf: anchorDate)
+        if case .up(let delta) = score.trend {
+            XCTAssertEqual(delta, 200) // current 4*100 - previous 2*100
+        } else {
+            XCTFail("Expected .up trend, got \(score.trend)")
+        }
+    }
+
+    func testTrendIsDownWhenCurrentBelowPrevious() {
+        let sessions = [
+            session(daysAgo: 35),
+            session(daysAgo: 40),
+            session(daysAgo: 45)
+        ]
+        let score = StrengthScoreEngine.score(sessions: sessions, setLogs: [], asOf: anchorDate)
+        if case .down(let delta) = score.trend {
+            XCTAssertEqual(delta, 300) // 0 - 3*100 = -300, magnitude 300
+        } else {
+            XCTFail("Expected .down trend, got \(score.trend)")
+        }
+    }
+
+    func testTrendIsFlatWhenIdentical() {
+        // Same one session in both windows? Place one each side at exact -28
+        // boundary. Actually easier: two sessions positioned symmetrically.
+        let sessions = [
+            session(daysAgo: 14),
+            session(daysAgo: 42)
+        ]
+        let score = StrengthScoreEngine.score(sessions: sessions, setLogs: [], asOf: anchorDate)
+        XCTAssertEqual(score.trend, .flat)
+    }
+
+    // MARK: - Trend points
+
+    func testTrendReturnsRequestedNumberOfWeeklyPoints() {
+        let points = StrengthScoreEngine.trend(
+            sessions: [],
+            setLogs: [],
+            asOf: anchorDate,
+            weeks: 12
+        )
+        XCTAssertEqual(points.count, 12)
+        // Points should be sorted oldest first
+        for (a, b) in zip(points, points.dropFirst()) {
+            XCTAssertLessThan(a.date, b.date)
+        }
+    }
+
+    func testTrendReflectsGrowthOverTime() {
+        // Add one session per week over 12 weeks. Each week's window picks
+        // up one more session than the previous.
+        var sessions: [WorkoutSession] = []
+        for offset in 0..<12 {
+            sessions.append(session(daysAgo: offset * 7))
+        }
+        let points = StrengthScoreEngine.trend(
+            sessions: sessions,
+            setLogs: [],
+            asOf: anchorDate,
+            weeks: 12
+        )
+        // The most recent point should have the highest score (most sessions
+        // in the trailing 28-day window).
+        let scores = points.map(\.score)
+        XCTAssertGreaterThan(scores.last!, scores.first!)
+    }
+
+    // MARK: - Helpers
+
+    private func date(daysAgo: Int) -> Date {
+        Calendar.current.date(byAdding: .day, value: -daysAgo, to: anchorDate)!
+    }
+
+    private func session(daysAgo: Int) -> WorkoutSession {
+        // The engine only reads session.date; other fields are irrelevant.
+        WorkoutSession(
+            date: date(daysAgo: daysAgo),
+            totalElapsed: 0,
+            exercisesCompleted: 0,
+            setsCompleted: 0
+        )
+    }
+
+    private func log(
+        daysAgo: Int,
+        weight: Double?,
+        reps: Int,
+        templateID: String? = "default-id",
+        name: String = "Default"
+    ) -> SetLog {
+        let log = SetLog(
+            exerciseName: name,
+            exerciseTemplateID: templateID,
+            setIndex: 0,
+            exerciseIndex: 0,
+            weight: weight,
+            reps: reps
+        )
+        // SetLog.init always sets date = .now; override for the test.
+        log.date = date(daysAgo: daysAgo)
+        return log
+    }
+}


### PR DESCRIPTION
## Summary
A Fitbod-style "Fitness Level" surfacing — closes [parity item #6](https://github.com/nsluke/Lazer-Dragon-Workout-Experience/blob/master/) (the "Strength Score" entry in the Fitbod-parity roadmap).

The user gets one big number on the Body tab that they can watch grow. The score blends three components measured over a trailing 28-day window:
- **Strength** — sum of best Epley 1RM estimate per unique exercise template
- **Volume** — total weight × reps performed
- **Frequency** — number of distinct workout sessions

`total = strength + volume / 50 + frequency × 100`

Scaled so a regularly training intermediate lifter lands in the ~2,000–5,000 range. Intentionally **not** normalized to 0-100 — it grows as the user grows, the way Fitbod's number does.

## What's new
- `Models/StrengthScoreEngine.swift` — pure-struct engine, mirrors `MuscleAnalyzer` / `RecoveryAnalyzer`
- `Features/Body/StrengthScoreCard.swift` — big number + ▲/▼/→ delta + 12-week Swift Charts sparkline + 3-chip component breakdown
- Wired into `BodyStatusView` above the recovery bar
- `CodeDumpTests/StrengthScoreEngineTests.swift` — 13 unit tests covering empty state, each component, total formula, trend deltas (up/down/flat/unknown), 12-week trend series

## Test plan
- [x] 13/13 engine unit tests pass locally
- [x] Build succeeds (iPhone 17 Pro / iOS 26.3.1)
- [ ] Gate 1 green on this PR
- [ ] Manual: open the Body tab, see the score card with current total + sparkline
- [ ] Manual: log a heavy set, return to Body, confirm score increased and ▲ delta updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)