### PR TITLE
CI: continue-on-error for artifact upload step

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Upload Results
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: "nightly-${{ strategy.job-index }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,7 @@ jobs:
 
       - name: Upload Results
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: release-test-results

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,6 +110,7 @@ jobs:
 
       - name: Upload Results
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: gate1-results


### PR DESCRIPTION
## Summary
The 2026-05-12 nightly was marked failed even though every test on every device passed — the iPhone SE job's \`actions/upload-artifact@v4\` step timed out 5 times against \`twirp/github.actions.results.api.v1.ArtifactService/CreateArtifact\`. Known transient GitHub Actions infra flake; the other two devices happened to land in a non-flaky window.

The \`.xcresult\` bundles are diagnostic-only — losing one shouldn't take the dashboard red. Add \`continue-on-error: true\` to every \`Upload Results\` step in \`nightly.yml\`, \`release.yml\`, and \`tests.yml\`. The step still runs (and still posts a warning if it fails), but a failed upload no longer fails the parent job.

Pairs with PR #27's simulator-install retry — same shape, same goal: don't let GitHub Actions infrastructure flakes red-flag the dashboard.

## Test plan
- [x] Diff is workflow-only, no app code changes
- [ ] Gate 1 green on this PR (which won't exercise the new behavior, but should at least confirm syntax)
- [ ] Next scheduled nightly stays green even if the upload step warns

🤖 Generated with [Claude Code](https://claude.com/claude-code)